### PR TITLE
Added Husky hooks precommit and prepush for jest coverageThreshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,17 @@
   "homepage": "https://github.com/garageScript/databases#readme",
   "devDependencies": {
     "dotenv": "^8.2.0",
+    "husky": "^4.2.3",
     "jest": "^25.2.4",
     "pm2": "^4.2.3"
   },
   "dependencies": {
     "pg": "^8.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm test",
+      "pre-push": "npm test"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,16 @@
   "dependencies": {
     "pg": "^8.0.0"
   },
+  "jest": {
+    "coverageThreshold":{
+      "global":{
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100 
+      }
+    }
+  },
   "husky": {
     "hooks": {
       "pre-commit": "npm test",


### PR DESCRIPTION
* Will prevent jest tests from being committed if they fail to meet 100% threshold for their branches, functions, lines and statements. 