### PR TITLE
adds getEnvVar and change mailgun module, etc

### DIFF
--- a/lib/getEnvVar.js
+++ b/lib/getEnvVar.js
@@ -1,3 +1,4 @@
+
 module.exports = (type) => {
     if (type === 'mailgun') return { 
         apiKey: process.env.MAILGUN_API_KEY || '123', 

--- a/lib/getEnvVar.js
+++ b/lib/getEnvVar.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 
 module.exports = (type) => {
     if (type === 'mailgun') return { 

--- a/lib/getEnvVar.js
+++ b/lib/getEnvVar.js
@@ -1,0 +1,6 @@
+module.exports = (type) => {
+    if (type === 'mailgun') return { 
+        apiKey: process.env.MAILGUN_API_KEY || '123', 
+        domain: process.env.MAILGUN_DOMAIN 
+      }
+}

--- a/lib/getEnvVar.test.js
+++ b/lib/getEnvVar.test.js
@@ -1,0 +1,19 @@
+describe('test getEnvVar', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+    it('should return mailgun env var', () => {
+        process.env.MAILGUN_API_KEY = 'test key'
+        const getEnvVar = require('./getEnvVar')
+        expect(getEnvVar('mailgun').apiKey).toEqual('test key')
+    })
+    it('should return default mailgun env var', () => {
+        delete process.env.MAILGUN_API_KEY
+        const getEnvVar = require('./getEnvVar')
+        expect(getEnvVar('mailgun').apiKey).toEqual('123')
+    })
+    it('should return nothing without argument', () => {
+        const getEnvVar = require('./getEnvVar')
+        expect(getEnvVar()).toEqual(undefined)
+    })
+})

--- a/lib/getEnvVar.test.js
+++ b/lib/getEnvVar.test.js
@@ -1,3 +1,4 @@
+
 describe('test getEnvVar', () => {
     beforeEach(() => {
         jest.clearAllMocks()

--- a/lib/getEnvVar.test.js
+++ b/lib/getEnvVar.test.js
@@ -1,8 +1,4 @@
-
 describe('test getEnvVar', () => {
-    beforeEach(() => {
-        jest.clearAllMocks()
-    })
     it('should return mailgun env var', () => {
         process.env.MAILGUN_API_KEY = 'test key'
         const getEnvVar = require('./getEnvVar')

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Create databases in postgres, mongoDB and neo4J",
   "main": "index.js",
   "scripts": {
-    "test": "MAILGUN_API_KEY=123 jest --coverage",
+    "test": "jest --coverage",
     "start": "node index.js",
     "start:dev": "nodemon index.js"
   },

--- a/services/mailer.js
+++ b/services/mailer.js
@@ -1,11 +1,9 @@
 const mailgun = require('mailgun-js')
 const logger = require('../lib/log')(__filename)
+const getEnvVar = require('../lib/getEnvVar')
 require('dotenv').config()
 
-const mg = mailgun({ 
-  apiKey: process.env.MAILGUN_API_KEY, 
-  domain: process.env.MAILGUN_DOMAIN 
-})
+const mg = mailgun(getEnvVar('mailgun'))
 
 const mgModule = {}
 

--- a/services/mailer.js
+++ b/services/mailer.js
@@ -1,7 +1,6 @@
 const mailgun = require('mailgun-js')
 const logger = require('../lib/log')(__filename)
 const getEnvVar = require('../lib/getEnvVar')
-require('dotenv').config()
 
 const mg = mailgun(getEnvVar('mailgun'))
 


### PR DESCRIPTION
This PR changes some code in order to make package.json script command works on Windows as well.
Instead of setting env var with command, it uses helper function (`getEnvVar`) to set default env var for tests.