### PR TITLE
 Create a layout template to avoid repetition

### DIFF
--- a/tests/integration/welcome.test.js
+++ b/tests/integration/welcome.test.js
@@ -14,15 +14,14 @@ describe('test welcome page', () => {
         const result = await fetch(baseUrl).then(r => r.text())
         expect(result).toMatchSnapshot()
     })
-    test('should render setDBpassword page correctly', async()=>{
-        const result = await fetch(baseUrl + 'setDBpassword').then(r=> r.text())
-        expect(result).toMatchSnapshot()
-    })
- 
     test('should render sign in page correctly', async()=>{
        const result = await fetch(baseUrl + 'signin').then(r=> r.text())
        expect(result).toMatchSnapshot()
    })
+   test('should render setDBpassword page correctly', async()=>{
+    const result = await fetch(baseUrl + 'setDBpassword').then(r=> r.text())
+    expect(result).toMatchSnapshot()
+})
    test('should render sign up page correctly', async() => {
        const result = await fetch(baseUrl + 'signup').then(r => r.text())
        expect(result).toMatchSnapshot()

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -1,0 +1,32 @@
+<!--views/partials/head.ejs-->
+<meta charset='UTF-8'>
+<title>Welcome to learndb.dev </title>
+
+<!--CSS (load bootstrap from a CDN)-->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/open-fonts@1.1.1/fonts/inter.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@exampledev/new.css@1.1.2/new.min.css">
+<style>
+    * {
+        text-align: center;
+    }
+    input {
+        width: 400px;
+        height: 40px;
+        margin: 5px;
+    }
+    button {
+        width: 400px;
+        height: 40px;
+        margin: 10px;
+    }
+    .card {
+        width: 450px;
+        margin: auto;
+    }
+    .subtitle {
+        margin: 10px;
+    }
+    .body {
+        margin: 10px;
+    }
+</style>


### PR DESCRIPTION
1. created 'partials' folder in 'views' folder
2. created a head.ejs file that contains the layout template (load bootstrap from a CDN and stylesheet in general)
3. updated signin.ejs, signup.ejs and setDBpassword.ejs by calling head.ejs in them
