### PR TITLE
Prevent users to move to databases page when log in fails

### DIFF
--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -295,8 +295,9 @@ exports[`test welcome page should render sign in page correctly 1`] = `
                 password: password.value
             })
         }).then(r => r.json()).then((r) => {
-            if (r.dbPassword) return location.href = '/setDBPassword' //path name is not decided yet  
-            return location.href = '/databases' //path name is not decided yet
+            if (r.error) return alert(r.error.message)
+            if (r.dbPassword) return location.href = '/setDBPassword'
+            return location.href = '/databases'
         })
     })
 </script>

--- a/views/signin.ejs
+++ b/views/signin.ejs
@@ -33,8 +33,9 @@
                 password: password.value
             })
         }).then(r => r.json()).then((r) => {
-            if (r.dbPassword) return location.href = '/setDBPassword' //path name is not decided yet  
-            return location.href = '/databases' //path name is not decided yet
+            if (r.error) return alert(r.error.message)
+            if (r.dbPassword) return location.href = '/setDBPassword'
+            return location.href = '/databases'
         })
     })
 </script>


### PR DESCRIPTION
Related issue: #132 [Bug]- Login not showing error

Signin page didn't check if login fails so it redirects users to the next page even when login fails
This PR fixes it.