### PR TITLE
Fix bug: sending resetPWemail makes users logged in

### DIFF
--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -34,7 +34,6 @@ routes.resetPasswordEmail = async (req, res) => {
   try {
     const account = await sendPasswordResetEmail(userAccount);
     logger.info(`user reset password email sent to user ${userAccount.id}`);
-    req.session.username = account.username;
     return res.status(200).json({ ...account.dataValues, password: null });
   } catch (err) {
     logger.error(`Could not send email to user ${userAccount.id}`);
@@ -165,6 +164,7 @@ routes.userResetPassword = async (req, res) => {
   try {
     const account = await resetUserPassword(token, password);
     logger.info("User password reset for", account.username);
+    req.session.username = account.username;
     return res.status(200).json({ ...account.dataValues, password: null });
   } catch (err) {
     logger.error("user reset password error:", err);

--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -428,6 +428,7 @@ exports[`test welcome page should render setPassword page correctly 1`] = `
             })
         }).then(r => r.json()).then((r) => {
             if (r.error) return alert(r.error.message)
+            if (r.dbPassword) return location.href = '/'
             return location.href = '/setDBPassword'
         }).catch((err) => {
             alert(\\"Setting password has failed. Please try again.\\", err)

--- a/views/setPassword.ejs
+++ b/views/setPassword.ejs
@@ -32,6 +32,7 @@
             })
         }).then(r => r.json()).then((r) => {
             if (r.error) return alert(r.error.message)
+            if (r.dbPassword) return location.href = '/'
             return location.href = '/setDBPassword'
         }).catch((err) => {
             alert("Setting password has failed. Please try again.", err)


### PR DESCRIPTION
* Related issue:
  * [Bug - Reset password] - User should Not be logged in after sending reset password email #145
  * [Bug - Reset Password] - After reset password success, user should be logged in. #147

1. I accidently put `req.session.username = account.username` in `resetPasswordEmail` router instead of `userResetPassword` (function names are so confusing). This PR moves it to the correct place

2. Also, setPassword page is used both when the user first signup and when they forgot their password, which means they can already have set up their DB password. So it should not redirect users to setDBPassword page if DB Password is already set. This PR fixes this as well.