### PR TITLE
Fix bug: logout script shouldn't render if not username

### DIFF
--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -50,19 +50,11 @@ exports[`test welcome page should render databases page correctly 1`] = `
 </html>
 <script>
   const home = document.querySelector('.home')
-  const logout = document.querySelector('.logout')
-
   home.addEventListener('click', () => {
     return location.href = '/'
   })
 
-  logout.addEventListener('click', () => {
-    fetch(\\"/api/session\\", {
-      method: \\"DELETE\\"
-    }).then((r) => {
-      return location.href = '/'
-    })
-  })
+  
 </script>
 
 <style>
@@ -170,19 +162,11 @@ exports[`test welcome page should render resetPassword page correctly 1`] = `
 </html>
 <script>
   const home = document.querySelector('.home')
-  const logout = document.querySelector('.logout')
-
   home.addEventListener('click', () => {
     return location.href = '/'
   })
 
-  logout.addEventListener('click', () => {
-    fetch(\\"/api/session\\", {
-      method: \\"DELETE\\"
-    }).then((r) => {
-      return location.href = '/'
-    })
-  })
+  
 </script>
 
 <main>
@@ -285,19 +269,11 @@ exports[`test welcome page should render setDBpassword page correctly 1`] = `
 </html>
 <script>
   const home = document.querySelector('.home')
-  const logout = document.querySelector('.logout')
-
   home.addEventListener('click', () => {
     return location.href = '/'
   })
 
-  logout.addEventListener('click', () => {
-    fetch(\\"/api/session\\", {
-      method: \\"DELETE\\"
-    }).then((r) => {
-      return location.href = '/'
-    })
-  })
+  
 </script>
 
 <main>
@@ -380,19 +356,11 @@ exports[`test welcome page should render setPassword page correctly 1`] = `
 </html>
 <script>
   const home = document.querySelector('.home')
-  const logout = document.querySelector('.logout')
-
   home.addEventListener('click', () => {
     return location.href = '/'
   })
 
-  logout.addEventListener('click', () => {
-    fetch(\\"/api/session\\", {
-      method: \\"DELETE\\"
-    }).then((r) => {
-      return location.href = '/'
-    })
-  })
+  
 </script>
 
 <main>
@@ -488,19 +456,11 @@ exports[`test welcome page should render sign in page correctly 1`] = `
 </html>
 <script>
   const home = document.querySelector('.home')
-  const logout = document.querySelector('.logout')
-
   home.addEventListener('click', () => {
     return location.href = '/'
   })
 
-  logout.addEventListener('click', () => {
-    fetch(\\"/api/session\\", {
-      method: \\"DELETE\\"
-    }).then((r) => {
-      return location.href = '/'
-    })
-  })
+  
 </script>
 
 <main>
@@ -594,19 +554,11 @@ exports[`test welcome page should render sign up page correctly 1`] = `
 </html>
 <script>
   const home = document.querySelector('.home')
-  const logout = document.querySelector('.logout')
-
   home.addEventListener('click', () => {
     return location.href = '/'
   })
 
-  logout.addEventListener('click', () => {
-    fetch(\\"/api/session\\", {
-      method: \\"DELETE\\"
-    }).then((r) => {
-      return location.href = '/'
-    })
-  })
+  
 </script>
 
 <div class=\\"card\\">
@@ -712,19 +664,11 @@ exports[`test welcome page should render welcome page correctly 1`] = `
 </html>
 <script>
   const home = document.querySelector('.home')
-  const logout = document.querySelector('.logout')
-
   home.addEventListener('click', () => {
     return location.href = '/'
   })
 
-  logout.addEventListener('click', () => {
-    fetch(\\"/api/session\\", {
-      method: \\"DELETE\\"
-    }).then((r) => {
-      return location.href = '/'
-    })
-  })
+  
 </script>
 
 <html lang=\\"en\\">

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -49,12 +49,12 @@
 </html>
 <script>
   const home = document.querySelector('.home')
-  const logout = document.querySelector('.logout')
-
   home.addEventListener('click', () => {
     return location.href = '/'
   })
 
+  <% if (username) { %>
+  const logout = document.querySelector('.logout')
   logout.addEventListener('click', () => {
     fetch("/api/session", {
       method: "DELETE"
@@ -62,4 +62,5 @@
       return location.href = '/'
     })
   })
+  <% } %>
 </script>


### PR DESCRIPTION
`head.ejs` has script tag which uses username variable.
However, if user is not logged in, this value is null so the page says error.
This PR fixes it.