### PR TITLE
Fix bug: setDBPassword page element class name is wrong

### DIFF
--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -304,7 +304,7 @@ exports[`test welcome page should render setDBpassword page correctly 1`] = `
     <div class=\\"card\\">
         <div class=\\"body\\">
             <h3 class=\\"subtitle\\">Set DB Password</h3>
-            <input class=\\"DB Password\\" placeholder=\\"password\\">
+            <input class=\\"dbPassword\\" placeholder=\\"password\\">
             <button class=\\"setButton\\">Set</button>
         </div>
     </div>

--- a/views/setDBpassword.ejs
+++ b/views/setDBpassword.ejs
@@ -3,7 +3,7 @@
     <div class="card">
         <div class="body">
             <h3 class="subtitle">Set DB Password</h3>
-            <input class="DB Password" placeholder="password">
+            <input class="dbPassword" placeholder="password">
             <button class="setButton">Set</button>
         </div>
     </div>


### PR DESCRIPTION
setDBPassword page doesn't work because script can't read input element value.
Because class name is wrong
It's `DB Password` but script is trying to get element with class name `dbPassword`
This PR changes `DB Password` to `dbPassword` so that they match