### PR TITLE
Bug: user should be logged in after setting pw

### DIFF
--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -162,6 +162,7 @@ routes.userResetPassword = async (req, res) => {
     const account = await resetUserPassword(token, password);
     logger.info("User password reset for", account.email);
     req.session.userid = account.id;
+    req.session.email = account.email;
     return res.status(200).json({ ...account.dataValues, password: null });
   } catch (err) {
     logger.error("user reset password error:", err);

--- a/src/routes/userRoutes.test.js
+++ b/src/routes/userRoutes.test.js
@@ -384,17 +384,18 @@ describe("testing userResetPassword", () => {
         token: userInfo,
         password: "testPassword",
       },
-      session: {
-        email: "em@i.l",
-      },
+      session: {},
     };
 
     await userResetPassword(req, res);
-    return expect(res.json.mock.calls[0][0]).toEqual({
+    expect(req.session.userid).toEqual(userInfo.id);
+    expect(req.session.email).toEqual(userInfo.email);
+    expect(res.json.mock.calls[0][0]).toEqual({
       password: null,
       id: 2,
       email: "em@i.l",
     });
+    return;
   });
   it("should return error if reset user password fails", async () => {
     const userInfo = {


### PR DESCRIPTION
I missed `req.session.email = account.email` in `userResetPassword` function.
This PR fixes it.