### PR TITLE
Add setTimeout in integration test

### DIFF
--- a/tests/integration/welcome.test.js
+++ b/tests/integration/welcome.test.js
@@ -1,6 +1,9 @@
+jest.setTimeout(10000);
+
 const session = require("express-session");
 const { startServer, stopServer } = require("../../src/server");
 const fetch = require("node-fetch");
+require("dotenv").config();
 
 describe("test welcome page", () => {
   const testPort = process.env.TEST_PORT || 20200;


### PR DESCRIPTION
## Issue
![image](https://user-images.githubusercontent.com/61715204/91867292-720ada80-ecae-11ea-8a8e-69712611e816.png)
* Sometimes it takes too long when the integration test starts the test server so it gets this error

## What this PR does
* It adds `jest.setTimeout(10000)` to `welcome.test.js` file. Then it worked okay with me :)