### PR TITLE
take out js from set password email content

### DIFF
--- a/services/__snapshots__/mailer.test.js.snap
+++ b/services/__snapshots__/mailer.test.js.snap
@@ -9,7 +9,7 @@ Object {
           <hr>
           <div id=\\"content\\">
             <p>You have requested a (re)set password token. The button below will redirect you to our website with an autheticated token. Please click the button and set your password.</p>
-            <button id=\\"button\\" onclick=\\"window.open('https://learndatabases.dev/setPassword/token123')\\">Set my Password</button>
+            <a href=\\"https://learndatabases.dev/setPassword/token123\\" target=\\"_blank\\" id=\\"button\\">Set my Password</a>
             <p><small><b style=\\"color: red\\">Warning</b>: Anyone with access to this email has access to your account. Don't share this email with other people.</small></p> 
           </div>
         </div>

--- a/services/mailer.js
+++ b/services/mailer.js
@@ -19,7 +19,7 @@ mgModule.sendPasswordResetEmail = (receiver, token) => {
           <hr>
           <div id="content">
             <p>You have requested a (re)set password token. The button below will redirect you to our website with an autheticated token. Please click the button and set your password.</p>
-            <button id="button" onclick="window.open('${link}')">Set my Password</button>
+            <a href="${link}" target="_blank" id="button">Set my Password</a>
             <p><small><b style="color: red">Warning</b>: Anyone with access to this email has access to your account. Don't share this email with other people.</small></p> 
           </div>
         </div>


### PR DESCRIPTION
## Issue
This part of the set password email is currently button with onclick triggered javascript function. This will not run in most email clients.
    ![CBEDE46A-F278-4068-91D8-046DDD913904](https://user-images.githubusercontent.com/61715204/92293955-77904b00-ef62-11ea-8e9f-1082bc2011b6.jpeg)

## What this PR does
It changes button tag to anchor tag with href attribute. 