### PR TITLE
Add Umami Tracking Code

### DIFF
--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -120,6 +120,8 @@ exports[`test welcome page should render postgres page correctly 1`] = `
     })
   </script>
 
+  <script async defer data-website-id=\\"d367293a-0e30-4ae1-bdce-3651e1b64909\\" src=\\"https://analytics.learndatabases.dev/umami.js\\"></script>
+
 </html>
 "
 `;
@@ -651,6 +653,8 @@ exports[`test welcome page should render welcome page correctly 1`] = `
       location.href = '/neo4j'
     })
   </script>
+
+  <script async defer data-website-id=\\"d367293a-0e30-4ae1-bdce-3651e1b64909\\" src=\\"https://analytics.learndatabases.dev/umami.js\\"></script>
 
 </html>
 "

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -62,4 +62,6 @@
     })
   </script>
 
+  <script async defer data-website-id="d367293a-0e30-4ae1-bdce-3651e1b64909" src="https://analytics.learndatabases.dev/umami.js"></script>
+
 </html>


### PR DESCRIPTION
We just setup umami in the server.
[Click here](https://analytics.learndatabases.dev) to go to umami.
Admin username / password is shared in private chat.
This PR adds tracking code(script tag) on the landing page, which sends data to our umami