### PR TITLE
closes #207 - Fix links and update messages the user sees

### DIFF
--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -91,9 +91,17 @@ exports[`test welcome page should render postgres page correctly 1`] = `
       </li>
     </ul>
 
-    <p>Want to add a new Database or Sponsor? <a href=\\"https://github.com/garageScript/databases/issues\\">Contact Us</a></p>
+    <p>Want to add a new Database or Sponsor? 
+			<a href=\\"https://github.com/garageScript/databases/issues\\">Contact Us</a>
+		</p>
 
-    <p>We collect anonymous analytics using <a href=\\"https://umami.is/\\">Umami</a>. View live: <a href=\\"https://analytics.learndatabases.dev/share/9DRDvLQJ/LearnDatabases\\">analytics.learndatabases.dev</a></p>
+		<p>We collect anonymous analytics using 
+			<a href=\\"https://umami.is/\\">Umami</a>. 
+			View live: 
+			<a href=\\"https://analytics.learndatabases.dev/share/9DRDvLQJ/LearnDatabases\\">
+				analytics.learndatabases.dev
+			</a>
+		</p>
 
   </body>
 
@@ -632,9 +640,17 @@ exports[`test welcome page should render welcome page correctly 1`] = `
       </li>
     </ul>
 
-    <p>Want to add a new Database or Sponsor? <a href=\\"https://github.com/garageScript/databases/issues\\">Contact Us</a></p>
+    <p>Want to add a new Database or Sponsor? 
+			<a href=\\"https://github.com/garageScript/databases/issues\\">Contact Us</a>
+		</p>
 
-    <p>We collect anonymous analytics using <a href=\\"https://umami.is/\\">Umami</a>. View live: <a href=\\"https://analytics.learndatabases.dev/share/9DRDvLQJ/LearnDatabases\\">analytics.learndatabases.dev</a></p>
+		<p>We collect anonymous analytics using 
+			<a href=\\"https://umami.is/\\">Umami</a>. 
+			View live: 
+			<a href=\\"https://analytics.learndatabases.dev/share/9DRDvLQJ/LearnDatabases\\">
+				analytics.learndatabases.dev
+			</a>
+		</p>
 
   </body>
 

--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -72,12 +72,12 @@ exports[`test welcome page should render postgres page correctly 1`] = `
         <h4 class=\\"db-title\\">Elasticsearch</h4>
         <p class=\\"db-discription\\">A highly scalable full-text search analytics engine. It allows you to store, search and analyze big volumes of data quickly and in near real time.</p>
       </blockquote>
-      <blockquote id=\\"mongodb\\" class=\\"db-card\\">
-        <h4 class=\\"db-title\\">MongoDB</h4>
+      <blockquote id=\\"mongodb\\" class=\\"db-card darkenCards\\">
+        <h4 class=\\"db-title\\">MongoDB (coming next sprint!)</h4>
         <p class=\\"db-discription\\">An open source database management system using a document-oriented database model that supports various forms of data.<p>
-      </blockquote>
-      <blockquote id=\\"neo4j\\" class=\\"db-card\\">
-        <h4 class=\\"db-title\\">Neo4j</h4>
+			</blockquote>
+      <blockquote id=\\"neo4j\\" class=\\"db-card darkenCards\\">
+        <h4 class=\\"db-title\\">Neo4j (coming next sprint!)</h4>
         <p class=\\"db-discription\\">A graph database management system that is the most popular graph database and the 22nd most popular database overall.</p>
       </blockquote>
 
@@ -91,9 +91,9 @@ exports[`test welcome page should render postgres page correctly 1`] = `
       </li>
     </ul>
 
-    <p>Want to add a new Database or Sponsor? <a href=\\"#\\">Contact Us</a></p>
+    <p>Want to add a new Database or Sponsor? <a href=\\"https://github.com/garageScript/databases/issues\\">Contact Us</a></p>
 
-    <p>We collect anonymous analytics using Simple Analytics. View live: <a href=\\"#\\">simpleanalytics.com/learndatabases.dev</a></p>
+    <p>We collect anonymous analytics using <a href=\\"https://umami.is/\\">Umami</a>. View live: <a href=\\"https://analytics.learndatabases.dev/share/9DRDvLQJ/LearnDatabases\\">analytics.learndatabases.dev</a></p>
 
   </body>
 
@@ -101,6 +101,9 @@ exports[`test welcome page should render postgres page correctly 1`] = `
     .db-card {
       cursor: pointer;
     }
+		.darkenCards {
+			opacity: 60%;
+		}
     .db-card:hover {
       border-left: solid 5px rgb(10, 70, 120);
     }
@@ -111,13 +114,15 @@ exports[`test welcome page should render postgres page correctly 1`] = `
     })
     document.getElementById('elastic').addEventListener('click', () => {
       location.href = '/elasticsearch'
-    })
+		})
+		/*
     document.getElementById('mongodb').addEventListener('click', () => {
       location.href = '/mongodb'
     })
     document.getElementById('neo4j').addEventListener('click', () => {
       location.href = '/neo4j'
-    })
+		})
+		*/
   </script>
 
   <script async defer data-website-id=\\"d367293a-0e30-4ae1-bdce-3651e1b64909\\" src=\\"https://analytics.learndatabases.dev/umami.js\\"></script>
@@ -184,40 +189,44 @@ exports[`test welcome page should render resetPassword page correctly 1`] = `
 </script>
 
 <main>
-    <div class=\\"card\\">
-        <div class=\\"body\\">
-            <h3 class=\\"subtitle\\">Reset your password</h3>
-            <input class=\\"email\\" placeholder=\\"Email\\" /><br>
-            <button class=\\"submit\\">Submit</button>
-        </div>
-        <div class=\\"tale\\">
-            <div>Wanna go back? <a href=\\"/signin\\">Log In</a></div>
-        </div>
+  <div class=\\"card\\">
+    <div class=\\"body\\">
+      <h3 class=\\"subtitle\\">Reset your password</h3>
+      <input class=\\"email\\" placeholder=\\"Email\\" /><br />
+      <button class=\\"submit\\">Submit</button>
     </div>
+    <div class=\\"tale\\">
+      <div>Wanna go back? <a href=\\"/signin\\">Log In</a></div>
+    </div>
+  </div>
 </main>
 
 <script>
-  const submit = document.querySelector('.submit');
-  const email = document.querySelector('.email');
+  const submit = document.querySelector(\\".submit\\");
+  const email = document.querySelector(\\".email\\");
 
-  submit.addEventListener('click', () => {
-    fetch('/api/notifications', {
+  submit.addEventListener(\\"click\\", () => {
+    fetch(\\"/api/notifications\\", {
       method: \\"POST\\",
       headers: {
-        'content-type': 'application/json'
+        \\"content-type\\": \\"application/json\\",
       },
       body: JSON.stringify({
-        email: email.value
-      })
-    }).then(r => r.json()).then((r) => {
-      if (r.error) {
-        alert(r.error.message)
-      } else {
-        alert(\\"Check your email and set your password\\")
-        return location.href = '/signin'
-      }
+        email: email.value,
+      }),
     })
-  })
+      .then((r) => r.json())
+      .then((r) => {
+        if (r.error) {
+          alert(r.error.message);
+        } else {
+          alert(
+            \\"Check your email (don't forget to check the spam box!) and set your password\\"
+          );
+          return (location.href = \\"/signin\\");
+        }
+      });
+  });
 </script>
 "
 `;
@@ -494,43 +503,41 @@ exports[`test welcome page should render sign up page correctly 1`] = `
 <div class=\\"card\\">
   <div class=\\"body\\">
     <h3 class=\\"subtitle\\">Create Account</h3>
-    <input
-      class=\\"email\\"
-      type=\\"email\\"
-      placeholder=\\"Email Address\\"
-      required
-      />
+    <input class=\\"email\\" type=\\"email\\" placeholder=\\"Email Address\\" required />
     <button class=\\"submit\\">Create Account</button>
   </div>
-  <div class=\\"tale\\">
-    Already have an account? <a href=\\"/signin\\">Login</a>
-  </div>
+  <div class=\\"tale\\">Already have an account? <a href=\\"/signin\\">Login</a></div>
 
-<script>
-  const submit = document.querySelector('.submit');
-  const check = document.querySelector('.check');
-  const email = document.querySelector('.email')
+  <script>
+    const submit = document.querySelector(\\".submit\\");
+    const check = document.querySelector(\\".check\\");
+    const email = document.querySelector(\\".email\\");
 
-  submit.addEventListener('click', () => {
-    fetch('/api/users', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        email: email.value.toLowerCase()
+    submit.addEventListener(\\"click\\", () => {
+      fetch(\\"/api/users\\", {
+        method: \\"POST\\",
+        headers: {
+          \\"Content-Type\\": \\"application/json\\",
+        },
+        body: JSON.stringify({
+          email: email.value.toLowerCase(),
+        }),
       })
-    }).then(r => r.json()).then((res) => {
-      if (res.error) {
-        const message = res.error.message
-        alert(message)
-      } else {
-        alert(\\"Check your email and set your password\\")
-        return location.href = '/signin'
-      }
-    })
-  })
-</script>
+        .then((r) => r.json())
+        .then((res) => {
+          if (res.error) {
+            const message = res.error.message;
+            alert(message);
+          } else {
+            alert(
+              \\"Check your email (don't forget to check the spam box!) and set your password\\"
+            );
+            return (location.href = \\"/signin\\");
+          }
+        });
+    });
+  </script>
+</div>
 "
 `;
 
@@ -606,12 +613,12 @@ exports[`test welcome page should render welcome page correctly 1`] = `
         <h4 class=\\"db-title\\">Elasticsearch</h4>
         <p class=\\"db-discription\\">A highly scalable full-text search analytics engine. It allows you to store, search and analyze big volumes of data quickly and in near real time.</p>
       </blockquote>
-      <blockquote id=\\"mongodb\\" class=\\"db-card\\">
-        <h4 class=\\"db-title\\">MongoDB</h4>
+      <blockquote id=\\"mongodb\\" class=\\"db-card darkenCards\\">
+        <h4 class=\\"db-title\\">MongoDB (coming next sprint!)</h4>
         <p class=\\"db-discription\\">An open source database management system using a document-oriented database model that supports various forms of data.<p>
-      </blockquote>
-      <blockquote id=\\"neo4j\\" class=\\"db-card\\">
-        <h4 class=\\"db-title\\">Neo4j</h4>
+			</blockquote>
+      <blockquote id=\\"neo4j\\" class=\\"db-card darkenCards\\">
+        <h4 class=\\"db-title\\">Neo4j (coming next sprint!)</h4>
         <p class=\\"db-discription\\">A graph database management system that is the most popular graph database and the 22nd most popular database overall.</p>
       </blockquote>
 
@@ -625,9 +632,9 @@ exports[`test welcome page should render welcome page correctly 1`] = `
       </li>
     </ul>
 
-    <p>Want to add a new Database or Sponsor? <a href=\\"#\\">Contact Us</a></p>
+    <p>Want to add a new Database or Sponsor? <a href=\\"https://github.com/garageScript/databases/issues\\">Contact Us</a></p>
 
-    <p>We collect anonymous analytics using Simple Analytics. View live: <a href=\\"#\\">simpleanalytics.com/learndatabases.dev</a></p>
+    <p>We collect anonymous analytics using <a href=\\"https://umami.is/\\">Umami</a>. View live: <a href=\\"https://analytics.learndatabases.dev/share/9DRDvLQJ/LearnDatabases\\">analytics.learndatabases.dev</a></p>
 
   </body>
 
@@ -635,6 +642,9 @@ exports[`test welcome page should render welcome page correctly 1`] = `
     .db-card {
       cursor: pointer;
     }
+		.darkenCards {
+			opacity: 60%;
+		}
     .db-card:hover {
       border-left: solid 5px rgb(10, 70, 120);
     }
@@ -645,13 +655,15 @@ exports[`test welcome page should render welcome page correctly 1`] = `
     })
     document.getElementById('elastic').addEventListener('click', () => {
       location.href = '/elasticsearch'
-    })
+		})
+		/*
     document.getElementById('mongodb').addEventListener('click', () => {
       location.href = '/mongodb'
     })
     document.getElementById('neo4j').addEventListener('click', () => {
       location.href = '/neo4j'
-    })
+		})
+		*/
   </script>
 
   <script async defer data-website-id=\\"d367293a-0e30-4ae1-bdce-3651e1b64909\\" src=\\"https://analytics.learndatabases.dev/umami.js\\"></script>

--- a/views/resetPassword.ejs
+++ b/views/resetPassword.ejs
@@ -1,37 +1,41 @@
 <%- include('./partials/head') %>
 <main>
-    <div class="card">
-        <div class="body">
-            <h3 class="subtitle">Reset your password</h3>
-            <input class="email" placeholder="Email" /><br>
-            <button class="submit">Submit</button>
-        </div>
-        <div class="tale">
-            <div>Wanna go back? <a href="/signin">Log In</a></div>
-        </div>
+  <div class="card">
+    <div class="body">
+      <h3 class="subtitle">Reset your password</h3>
+      <input class="email" placeholder="Email" /><br />
+      <button class="submit">Submit</button>
     </div>
+    <div class="tale">
+      <div>Wanna go back? <a href="/signin">Log In</a></div>
+    </div>
+  </div>
 </main>
 
 <script>
-  const submit = document.querySelector('.submit');
-  const email = document.querySelector('.email');
+  const submit = document.querySelector(".submit");
+  const email = document.querySelector(".email");
 
-  submit.addEventListener('click', () => {
-    fetch('/api/notifications', {
+  submit.addEventListener("click", () => {
+    fetch("/api/notifications", {
       method: "POST",
       headers: {
-        'content-type': 'application/json'
+        "content-type": "application/json",
       },
       body: JSON.stringify({
-        email: email.value
-      })
-    }).then(r => r.json()).then((r) => {
-      if (r.error) {
-        alert(r.error.message)
-      } else {
-        alert("Check your email and set your password")
-        return location.href = '/signin'
-      }
+        email: email.value,
+      }),
     })
-  })
+      .then((r) => r.json())
+      .then((r) => {
+        if (r.error) {
+          alert(r.error.message);
+        } else {
+          alert(
+            "Check your email (don't forget to check the spam box!) and set your password"
+          );
+          return (location.href = "/signin");
+        }
+      });
+  });
 </script>

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -2,40 +2,38 @@
 <div class="card">
   <div class="body">
     <h3 class="subtitle">Create Account</h3>
-    <input
-      class="email"
-      type="email"
-      placeholder="Email Address"
-      required
-      />
+    <input class="email" type="email" placeholder="Email Address" required />
     <button class="submit">Create Account</button>
   </div>
-  <div class="tale">
-    Already have an account? <a href="/signin">Login</a>
-  </div>
+  <div class="tale">Already have an account? <a href="/signin">Login</a></div>
 
-<script>
-  const submit = document.querySelector('.submit');
-  const check = document.querySelector('.check');
-  const email = document.querySelector('.email')
+  <script>
+    const submit = document.querySelector(".submit");
+    const check = document.querySelector(".check");
+    const email = document.querySelector(".email");
 
-  submit.addEventListener('click', () => {
-    fetch('/api/users', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        email: email.value.toLowerCase()
+    submit.addEventListener("click", () => {
+      fetch("/api/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: email.value.toLowerCase(),
+        }),
       })
-    }).then(r => r.json()).then((res) => {
-      if (res.error) {
-        const message = res.error.message
-        alert(message)
-      } else {
-        alert("Check your email and set your password")
-        return location.href = '/signin'
-      }
-    })
-  })
-</script>
+        .then((r) => r.json())
+        .then((res) => {
+          if (res.error) {
+            const message = res.error.message;
+            alert(message);
+          } else {
+            alert(
+              "Check your email (don't forget to check the spam box!) and set your password"
+            );
+            return (location.href = "/signin");
+          }
+        });
+    });
+  </script>
+</div>

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -33,9 +33,17 @@
       </li>
     </ul>
 
-    <p>Want to add a new Database or Sponsor? <a href="https://github.com/garageScript/databases/issues">Contact Us</a></p>
+    <p>Want to add a new Database or Sponsor? 
+			<a href="https://github.com/garageScript/databases/issues">Contact Us</a>
+		</p>
 
-    <p>We collect anonymous analytics using <a href="https://umami.is/">Umami</a>. View live: <a href="https://analytics.learndatabases.dev/share/9DRDvLQJ/LearnDatabases">analytics.learndatabases.dev</a></p>
+		<p>We collect anonymous analytics using 
+			<a href="https://umami.is/">Umami</a>. 
+			View live: 
+			<a href="https://analytics.learndatabases.dev/share/9DRDvLQJ/LearnDatabases">
+				analytics.learndatabases.dev
+			</a>
+		</p>
 
   </body>
 

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -14,12 +14,12 @@
         <h4 class="db-title">Elasticsearch</h4>
         <p class="db-discription">A highly scalable full-text search analytics engine. It allows you to store, search and analyze big volumes of data quickly and in near real time.</p>
       </blockquote>
-      <blockquote id="mongodb" class="db-card">
-        <h4 class="db-title">MongoDB</h4>
+      <blockquote id="mongodb" class="db-card darkenCards">
+        <h4 class="db-title">MongoDB (coming next sprint!)</h4>
         <p class="db-discription">An open source database management system using a document-oriented database model that supports various forms of data.<p>
-      </blockquote>
-      <blockquote id="neo4j" class="db-card">
-        <h4 class="db-title">Neo4j</h4>
+			</blockquote>
+      <blockquote id="neo4j" class="db-card darkenCards">
+        <h4 class="db-title">Neo4j (coming next sprint!)</h4>
         <p class="db-discription">A graph database management system that is the most popular graph database and the 22nd most popular database overall.</p>
       </blockquote>
 
@@ -33,9 +33,9 @@
       </li>
     </ul>
 
-    <p>Want to add a new Database or Sponsor? <a href="#">Contact Us</a></p>
+    <p>Want to add a new Database or Sponsor? <a href="https://github.com/garageScript/databases/issues">Contact Us</a></p>
 
-    <p>We collect anonymous analytics using Simple Analytics. View live: <a href="#">simpleanalytics.com/learndatabases.dev</a></p>
+    <p>We collect anonymous analytics using <a href="https://umami.is/">Umami</a>. View live: <a href="https://analytics.learndatabases.dev/share/9DRDvLQJ/LearnDatabases">analytics.learndatabases.dev</a></p>
 
   </body>
 
@@ -43,6 +43,9 @@
     .db-card {
       cursor: pointer;
     }
+		.darkenCards {
+			opacity: 60%;
+		}
     .db-card:hover {
       border-left: solid 5px rgb(10, 70, 120);
     }
@@ -53,13 +56,15 @@
     })
     document.getElementById('elastic').addEventListener('click', () => {
       location.href = '/elasticsearch'
-    })
+		})
+		/*
     document.getElementById('mongodb').addEventListener('click', () => {
       location.href = '/mongodb'
     })
     document.getElementById('neo4j').addEventListener('click', () => {
       location.href = '/neo4j'
-    })
+		})
+		*/
   </script>
 
   <script async defer data-website-id="d367293a-0e30-4ae1-bdce-3651e1b64909" src="https://analytics.learndatabases.dev/umami.js"></script>


### PR DESCRIPTION
# The problems
* The user should be reminded to check their spam box when they reset their password or signup for an account
* The user should know which databases that are not available yet
* The `analytics` and `contact us` need to be fixed -- right now they redirect to the home page.

# This PR will:
1) Remind users to check their spambox through altering the alert messages on the signup and resetPassword pages
    <img width="456" alt="Screen Shot 2020-09-21 at 9 17 59 PM" src="https://user-images.githubusercontent.com/45890848/93844128-008ccf00-fc51-11ea-9652-0716e69fe1ac.png">

2) Darken the databases that are not yet available, and put a little message beside the database name
    <img width="742" alt="Screen Shot 2020-09-21 at 9 12 56 PM" src="https://user-images.githubusercontent.com/45890848/93844155-139f9f00-fc51-11ea-86a6-fa9d4f16ba84.png">

3) Fix links
    * Point the `analytics` to the analytics page
    * Point the `contact us` link to our github issues page
    * Put in a link to Umami 
    <img width="639" alt="Screen Shot 2020-09-21 at 9 11 22 PM" src="https://user-images.githubusercontent.com/45890848/93844202-4184e380-fc51-11ea-8448-fda84c44eac7.png">
