### PR TITLE
Docker image configuration 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:12-alpine
+WORKDIR /projects/databases
+COPY package*.json ./
+RUN npm install
+COPY . .
+CMD [ "node", "index.js" ]


### PR DESCRIPTION
**Dockerizing the whole project**

Docker hub repo with current release `https://hub.docker.com/r/ulisseus/learn_databases`
You need to have docker installed and a valid .env file. 
 
To start it run `docker run --env-file ${PATH_TO_YOUR_ENV_FILE} -p xxxx:yyyy ulisseus/learn_databases` where xxxx is your selected port and yyyy is PORT variable in your env file. For example `docker run --env-file ~/projects/databases/conf -p 4000:7000 ulisseus/learn_databases` uses conf as .env file and binds local 4000 port to port 7000 in container. 

 - Cons: current image is rather big (about 700mb) even with node-alpine. Any suggestions to reduce it are welcome. 
