### PR TITLE
Docker image configuration 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:12-alpine
+WORKDIR /projects/databases
+COPY package*.json ./
+RUN npm install 
+COPY . .
+CMD [ "node", "index.js" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.7"
+services:
+  postgres:
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: learndb_dev
+    volumes:
+      - ./pgdata:/var/lib/postgresql/data
+    ports:
+      - "5111:5432"
+  elastic:
+    image: "elasticsearch:7.9.2"
+    ports:
+        - "9200:9200"
+    environment: 
+      discovery.type: single-node 
+      xpack.security.enabled: "true"
+      ELASTIC_PASSWORD: test
+    volumes:
+      - ./esdata:/usr/share/elasticsearch/data
+
+  web:
+    environment: 
+        ES_HOST: "http://elastic:9200"
+        HOST: postgres
+        DATABASE: learndb_dev
+        PG_USER: postgres
+        PASSWORD: postgres
+        ES_PASSWORD: test
+    image: ulisseus/learn_databases
+    depends_on:
+      - postgres
+      - elastic
+    ports:
+      - "4000:4000" 


### PR DESCRIPTION
**Dockerizing the whole project**

`docker build -t <your_tag> .` rebuilds the image, you need to have docker and docker-compose installed. To start run `docker-compose up`. By default app starts at localhost:4000, environment variables in `docker-compose.yml` can change host and port. 

`docker exec -it <container id> npm run test` runs tests inside container. 

Docker hub repo with current release `https://hub.docker.com/r/ulisseus/learn_databases`

- Current image is rather big (about 700mb) any suggestions to reduce its size are welcome. I can't use elastic-alpine since I need x-pack features unfortunately. 
 - Sending emails is not possible since image uses dummy values for mailer api. 