### PR TITLE
closes #238 - Display tutorial for Arango 

### DIFF
--- a/database/arango/arango.js
+++ b/database/arango/arango.js
@@ -20,7 +20,7 @@ arangoModule.checkIfDatabaseExists = async (username) => {
   return res;
 };
 
-arangoModule.startArangoDB = async () => {
+arangoModule.startArangoDB = () => {
   try {
     db = new Database({
       url: process.env.ARANGO_URL,

--- a/database/arango/arango.js
+++ b/database/arango/arango.js
@@ -6,11 +6,18 @@ const logger = require("./../../lib/log")(__filename);
 const arangoModule = {};
 let db;
 
-arangoModule.checkIfDatabaseExists = async (name) => {
-  // returns array of objects containing a '_name' key.
-  // Ex [{ _name: 'lol' }, { _name: 'cakes' }]
-  const names = await db.databases();
-  return names.map((db) => db._name).includes(name);
+arangoModule.checkIfDatabaseExists = async (username) => {
+  const db = new Database({
+    url: process.env.ARANGO_URL,
+    databaseName: username,
+    auth: {
+      username: process.env.ARANGO_USER,
+      password: process.env.ARANGO_PW,
+    },
+  });
+  const res = await db.exists();
+  db.close();
+  return res;
 };
 
 arangoModule.startArangoDB = async () => {

--- a/database/arango/arango.test.js
+++ b/database/arango/arango.test.js
@@ -125,10 +125,13 @@ describe("ArangoDB functions", () => {
   });
 
   test("should call Database function and FAIL", () => {
-    Arango.Database.mockImplementation(() => {
-      throw new Error();
-    });
-    startArangoDB();
+    try {
+      Arango.Database.mockImplementation(() => {
+        throw new Error();
+      });
+      startArangoDB();
+    } catch (err) {}
+
     expect(logger.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/database/elasticsearch/elastic.test.js
+++ b/database/elasticsearch/elastic.test.js
@@ -105,7 +105,7 @@ describe("testing es delete account function", () => {
     } catch (err) {}
     return expect(logger.error).toHaveBeenCalled();
   });
-  it("should log info if deleting user seccess", async () => {
+  it("should log info if deleting user success", async () => {
     const account = {
       username: "testuser",
       email: "em@i.l",
@@ -127,19 +127,7 @@ describe("testing es check account function", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  it("should log error if account data is invalid", async () => {
-    const account = {};
-    try {
-      await es.checkAccount(account);
-    } catch (err) {}
-    return expect(logger.error).toHaveBeenCalled();
-  });
   it("should return false if index does not exist", async () => {
-    const account = {
-      username: "testuser",
-      email: "em@i.l",
-      password: "1234qwer",
-    };
     fetch.mockReturnValue(
       Promise.resolve({
         json: () => {
@@ -147,15 +135,10 @@ describe("testing es check account function", () => {
         },
       })
     );
-    const result = await es.checkAccount(account);
+    const result = await es.checkAccount("testuser");
     return expect(result).toEqual(false);
   });
   it("should return true if index exists", async () => {
-    const account = {
-      username: "testuser",
-      email: "em@i.l",
-      password: "1234qwer",
-    };
     fetch.mockReturnValue(
       Promise.resolve({
         json: () => {
@@ -163,7 +146,20 @@ describe("testing es check account function", () => {
         },
       })
     );
-    const result = await es.checkAccount(account);
+    const result = await es.checkAccount("testuser");
     return expect(result).toEqual(true);
+  });
+  it("should log error if somethin goes wrong", async () => {
+    fetch.mockImplementation(() => {
+      throw new Error();
+    });
+    try {
+      await es.checkAccount("jeez");
+    } catch (err) {}
+    return expect(logger.error).toHaveBeenCalled();
+  });
+  it("should do nothing if username is a falsy value", async () => {
+    await es.checkAccount("");
+    return expect(fetch).toHaveBeenCalledTimes(0);
   });
 });

--- a/lib/sendFetch.js
+++ b/lib/sendFetch.js
@@ -11,7 +11,7 @@ const sendFetch = (path, method, body, authorization) => {
   body && (options.body = JSON.stringify(body));
   authorization && (options.headers.authorization = authorization);
 
-  return fetch(path, options).then((r) => r.json())
+  return fetch(path, options).then((r) => r.json());
 };
 
 module.exports = { sendFetch };

--- a/lib/sendFetch.js
+++ b/lib/sendFetch.js
@@ -11,7 +11,9 @@ const sendFetch = (path, method, body, authorization) => {
   body && (options.body = JSON.stringify(body));
   authorization && (options.headers.authorization = authorization);
 
-  return fetch(path, options).then((r) => r.json());
+  return fetch(path, options)
+    .then((r) => r.json())
+    .catch(console.log);
 };
 
 module.exports = { sendFetch };

--- a/lib/sendFetch.js
+++ b/lib/sendFetch.js
@@ -11,9 +11,7 @@ const sendFetch = (path, method, body, authorization) => {
   body && (options.body = JSON.stringify(body));
   authorization && (options.headers.authorization = authorization);
 
-  return fetch(path, options)
-    .then((r) => r.json())
-    .catch(console.log);
+  return fetch(path, options).then((r) => r.json())
 };
 
 module.exports = { sendFetch };

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,7 @@
 const { Op } = require("sequelize");
 const db = require("../sequelize/db");
 const pg = require("../database/postgres/pg");
+const arango = require("../database/arango/arango");
 const es = require("../database/elasticsearch/elastic");
 const logger = require("./log")(__filename);
 
@@ -25,12 +26,18 @@ util.cleanAnonymous = async () => {
     });
     logger.info(`${userAccount.length} expired accounts are found`);
     return Promise.all(
-      userAccount.map(async (e) => {
-        const pgDbExists = await pg.userHasPgAccount(e.username);
-        if (pgDbExists) await pg.deletePgAccount(e);
-        const esDbExists = await es.checkAccount(e);
-        if (esDbExists) await es.deleteAccount(e);
-        return await e.destroy();
+      userAccount.map(async (user) => {
+        const { username } = user;
+        const pgDbExists = await pg.userHasPgAccount(username);
+        if (pgDbExists) await pg.deletePgAccount(user);
+
+        const esDbExists = await es.checkAccount(username);
+        if (esDbExists) await es.deleteAccount(user);
+
+        const arangoDbExists = await arango.checkIfDatabaseExists(username);
+        if (arangoDbExists) await arango.deleteAccount(username);
+
+        return await user.destroy();
       })
     ).then(() => {
       logger.info("Cleaning expired accounts has completed");

--- a/lib/util.test.js
+++ b/lib/util.test.js
@@ -1,6 +1,7 @@
 jest.mock("sequelize");
 jest.mock("../sequelize/db");
 jest.mock("../database/postgres/pg");
+jest.mock("../database/arango/arango");
 jest.mock("../database/elasticsearch/elastic");
 jest.mock("./log");
 
@@ -8,6 +9,7 @@ const sequelize = require("sequelize");
 const db = require("../sequelize/db");
 const pg = require("../database/postgres/pg");
 const es = require("../database/elasticsearch/elastic");
+const arango = require("../database/arango/arango");
 
 sequelize.Op = { and: "and", lt: "lt" };
 const Accounts = {
@@ -18,6 +20,7 @@ db.getModels = () => {
 };
 pg.deletePgAccount = jest.fn();
 es.deleteAccount = jest.fn();
+arango.deleteAccount = jest.fn();
 const logGen = require("./log");
 const logger = {
   info: jest.fn(),
@@ -50,17 +53,21 @@ describe("Testing cleanAnonymous function", () => {
     Accounts.findAll.mockReturnValue([{ destroy: () => {} }]);
     pg.userHasPgAccount = () => false;
     es.checkAccount = () => false;
+    arango.checkIfDatabaseExists = () => false;
     await util.cleanAnonymous();
     expect(pg.deletePgAccount).not.toHaveBeenCalled();
     expect(es.deleteAccount).not.toHaveBeenCalled();
+    expect(arango.deleteAccount).not.toHaveBeenCalled();
   });
   it("should call database functions if expired accounts are found", async () => {
     Accounts.findAll.mockReturnValue([{ destroy: () => {} }]);
     pg.userHasPgAccount = () => true;
     es.checkAccount = () => true;
+    arango.checkIfDatabaseExists = () => true;
     await util.cleanAnonymous();
     expect(pg.deletePgAccount).toHaveBeenCalled();
     expect(es.deleteAccount).toHaveBeenCalled();
+    expect(arango.deleteAccount).toHaveBeenCalled();
   });
   it("should call logger.error if cleaning fails", async () => {
     Accounts.findAll.mockImplementation(() => {

--- a/public/lessons/Arango.md
+++ b/public/lessons/Arango.md
@@ -1,0 +1,58 @@
+# 1 Intro
+
+Arango is an application that to stores your application data and allows you to search for them via queries. It can store data for you in such a way that retrieving data is efficient.
+
+Arango is also a multi-model database, meaning it can store data in either tables or graphs!
+
+# 2 Basics
+
+To quickly help you get started, we will go over a few basic commands using [arangojs API](https://github.com/arangodb/arangojs) that you can follow along.
+
+## 2.1 Connect
+
+This section will show you how to start and close a connection to an Arango database.
+
+```
+const { Database } = require("arangojs");
+let db;
+
+// Run this function to connect to an Arango database!
+const startArangoDB = () => {
+  db = new Database({
+  	url: 'https://arangodb.songz.dev/',
+  	databaseName: '@username',
+  	auth: {
+  		username: '@username',
+  		password: '@dbPassword',
+  	},
+	});
+};
+
+// Run this function to stop a connection to an Arango database!
+const closeArangoDB = () => db.close();
+```
+
+## 2.2 Store and retrieve data
+
+Arango's official website has a great [tutorial](https://www.arangodb.com/docs/stable/aql/tutorial-crud.html) on how to create, read, update, or delete data from an Arango database.
+Arango has its own query language named `AQL`. Here is how you can run AQL commands:
+
+To run AQL commands, use `` db.query(aql`commands go here`)``
+Note that `db` in `db.query` comes from the startArangoDB function we used to connect to an Arango database.
+
+Here is an example query of data.
+
+```
+const { aql } = require("arangojs");
+
+const getPokemons = async () => {
+	const pokemons = await db.query(aql`
+		FOR c IN Characters
+    	RETURN c
+	`)
+}
+```
+
+# 3 End
+
+We are still learning about Arango. If you have interesting and helpful example or want to update this doc, please [let us know](https://github.com/garageScript/databases/issues)!

--- a/src/routes/renderRoutes.js
+++ b/src/routes/renderRoutes.js
@@ -6,7 +6,7 @@ require("dotenv").config();
 const routes = {};
 
 // This is the 'host' url for a person's database credentials
-const dbHostTable = {
+const dbHost = {
   Postgres: "learndatabases.dev",
   Elasticsearch: "elastic.learndatabases.dev",
   Arango: process.env.ARANGO_URL,
@@ -28,7 +28,7 @@ routes.database = async (req, res) => {
   const user = userid ? await Accounts.findOne({ where: { id: userid } }) : {};
   const { username, dbPassword } = user;
   const renderData = { email, username, dbPassword, database };
-  renderData.dbHost = dbHostTable[database];
+  renderData.dbHost = dbHost[database];
   renderData.dbExists = username ? await checkAccount[database](user) : false;
 
   res.render("tutorial", renderData);

--- a/src/routes/renderRoutes.js
+++ b/src/routes/renderRoutes.js
@@ -4,6 +4,7 @@ const pg = require("../../database/postgres/pg");
 const arangoModule = require("../../database/arango/arango");
 require("dotenv").config();
 const routes = {};
+
 // This is the 'host' url for a person's database credentials
 const dbHost = {
   Postgres: process.env.HOST,
@@ -24,9 +25,7 @@ const checkAccount = {
 };
 
 const CI = () => {
-  if (process.env.NODE_ENV === "CI" || process.env.NODE_ENV === "prod")
-    return true;
-  return false;
+  return process.env.NODE_ENV === "CI" || process.env.NODE_ENV === "prod";
 };
 
 // If you are here because you are implementing another database, then

--- a/src/routes/renderRoutes.js
+++ b/src/routes/renderRoutes.js
@@ -5,14 +5,15 @@ const arangoModule = require("../../database/arango/arango");
 require("dotenv").config();
 const routes = {};
 
-// This is the 'host' url for a person's database credentials
-const dbHost = {
+// This is for when a person is running the app on the local machine.
+const dev_dbHost = {
   Postgres: process.env.HOST,
   Elasticsearch: process.env.ES_HOST,
   Arango: process.env.ARANGO_URL,
 };
 
-const CIHost = {
+// This is the 'host' url for a person's database credentials in prod.
+const dbHost = {
   Postgres: "learndatabases.dev",
   Elasticsearch: "elastic.learndatabases.dev",
   Arango: "arangodb.learndatabases.dev",
@@ -24,7 +25,7 @@ const checkAccount = {
   Arango: arangoModule.checkIfDatabaseExists,
 };
 
-const CI = () => {
+const prod = () => {
   return process.env.NODE_ENV === "CI" || process.env.NODE_ENV === "prod";
 };
 
@@ -38,7 +39,7 @@ routes.database = async (req, res) => {
   const user = userid && (await Accounts.findOne({ where: { id: userid } }));
   const { username, dbPassword } = user || {};
   const renderData = { email, username, dbPassword, database };
-  renderData.dbHost = CI() ? CIHost[database] : dbHost[database];
+  renderData.dbHost = prod() ? dbHost[database] : dev_dbHost[database];
   renderData.dbExists = username && (await checkAccount[database](user));
 
   res.render("tutorial", renderData);

--- a/src/routes/renderRoutes.js
+++ b/src/routes/renderRoutes.js
@@ -23,7 +23,11 @@ const checkAccount = {
   Arango: arangoModule.checkIfDatabaseExists,
 };
 
-const CI = () => process.env.NODE_ENV === "CI";
+const CI = () => {
+  if (process.env.NODE_ENV === "CI" || process.env.NODE_ENV === "prod")
+    return true;
+  return false;
+};
 
 // If you are here because you are implementing another database, then
 // just add to the hashtables above! No need to touch down here.

--- a/src/routes/renderRoutes.js
+++ b/src/routes/renderRoutes.js
@@ -6,7 +6,7 @@ require("dotenv").config();
 const routes = {};
 
 // This is the 'host' url for a person's database credentials
-const dbHostHash = {
+const dbHostTable = {
   Postgres: "learndatabases.dev",
   Elasticsearch: "elastic.learndatabases.dev",
   Arango: process.env.ARANGO_URL,
@@ -28,7 +28,7 @@ routes.database = async (req, res) => {
   const user = userid ? await Accounts.findOne({ where: { id: userid } }) : {};
   const { username, dbPassword } = user;
   const renderData = { email, username, dbPassword, database };
-  renderData.dbHost = dbHostHash[database];
+  renderData.dbHost = dbHostTable[database];
   renderData.dbExists = username ? await checkAccount[database](user) : false;
 
   res.render("tutorial", renderData);

--- a/src/routes/renderRoutes.js
+++ b/src/routes/renderRoutes.js
@@ -5,7 +5,7 @@ const arangoModule = require("../../database/arango/arango");
 require("dotenv").config();
 const routes = {};
 
-// This is for when a person is running the app on the local machine.
+// This is for when a person is running the app on their local machine.
 const dev_dbHost = {
   Postgres: process.env.HOST,
   Elasticsearch: process.env.ES_HOST,

--- a/src/routes/renderRoutes.js
+++ b/src/routes/renderRoutes.js
@@ -23,7 +23,7 @@ const checkAccount = {
   Arango: arangoModule.checkIfDatabaseExists,
 };
 
-const CI_ENV = () => process.env.NODE_ENV === "CI";
+const CI = () => process.env.NODE_ENV === "CI";
 
 // If you are here because you are implementing another database, then
 // just add to the hashtables above! No need to touch down here.
@@ -35,7 +35,7 @@ routes.database = async (req, res) => {
   const user = userid && (await Accounts.findOne({ where: { id: userid } }));
   const { username, dbPassword } = user || {};
   const renderData = { email, username, dbPassword, database };
-  renderData.dbHost = CI_ENV() ? CIHost[database] : dbHost[database];
+  renderData.dbHost = CI() ? CIHost[database] : dbHost[database];
   renderData.dbExists = username && (await checkAccount[database](user));
 
   res.render("tutorial", renderData);

--- a/src/routes/renderRoutes.js
+++ b/src/routes/renderRoutes.js
@@ -7,7 +7,7 @@ const routes = {};
 
 // This is the 'host' url for a person's database credentials
 const dbHost = {
-  Postgres: "learndatabases.dev",
+  Postgres: process.env.HOST,
   Elasticsearch: process.env.ES_HOST,
   Arango: process.env.ARANGO_URL,
 };

--- a/src/routes/renderRoutes.js
+++ b/src/routes/renderRoutes.js
@@ -8,7 +8,7 @@ const routes = {};
 // This is the 'host' url for a person's database credentials
 const dbHost = {
   Postgres: "learndatabases.dev",
-  Elasticsearch: "elastic.learndatabases.dev",
+  Elasticsearch: process.env.ES_HOST,
   Arango: process.env.ARANGO_URL,
 };
 

--- a/src/routes/renderRoutes.test.js
+++ b/src/routes/renderRoutes.test.js
@@ -29,14 +29,6 @@ describe("Testing database router", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  test("when database function is called with non-logged in user and Arango parameter", async () => {
-    mockRequest.params.database = "Arango";
-    await database(mockRequest, mockResponse);
-    expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
-    expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
-      "https://arangodb.songz.dev/"
-    );
-  });
   test("when database function is called with non-logged in user and Postgres parameter", async () => {
     mockRequest.params.database = "Postgres";
     await database(mockRequest, mockResponse);

--- a/src/routes/renderRoutes.test.js
+++ b/src/routes/renderRoutes.test.js
@@ -4,6 +4,7 @@ jest.mock("../../database/postgres/pg");
 jest.mock("../../database/arango/arango");
 jest.mock("arangojs");
 const db = require("../../sequelize/db");
+const arango = require("../../database/arango/arango");
 const es = require("../../database/elasticsearch/elastic");
 const { database } = require("./renderRoutes");
 
@@ -24,6 +25,7 @@ const mockRequest = {
 };
 
 es.checkAccount = jest.fn();
+arango.checkIfDatabaseExists = jest.fn();
 
 describe("Testing database router", () => {
   beforeEach(() => {

--- a/src/routes/renderRoutes.test.js
+++ b/src/routes/renderRoutes.test.js
@@ -58,6 +58,7 @@ describe("Testing database router", () => {
     );
   });
   test("when database function is called with non-logged in user and Arango parameter", async () => {
+    process.env = { ...process.env, NODE_ENV: "dev" };
     mockRequest.params.database = "Arango";
     await database(mockRequest, mockResponse);
     expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
@@ -66,6 +67,7 @@ describe("Testing database router", () => {
     );
   });
   test("when database function is called with non-logged in user and Postgres parameter", async () => {
+    process.env = { ...process.env, NODE_ENV: "dev" };
     mockRequest.params.database = "Postgres";
     await database(mockRequest, mockResponse);
     expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
@@ -74,6 +76,7 @@ describe("Testing database router", () => {
     );
   });
   test("when database function is called with non-logged in user and Elasticsearch parameter", async () => {
+    process.env = { ...process.env, NODE_ENV: "dev" };
     mockRequest.params.database = "Elasticsearch";
     await database(mockRequest, mockResponse);
     expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
@@ -82,6 +85,7 @@ describe("Testing database router", () => {
     );
   });
   test("when database function is called with logged in user and Arango parameter", async () => {
+    process.env = { ...process.env, NODE_ENV: "dev" };
     mockRequest.session.userid = 999999;
     mockRequest.params.database = "Arango";
     mockFindOne.mockReturnValue({
@@ -95,6 +99,7 @@ describe("Testing database router", () => {
     );
   });
   test("when database function is called with logged in user and Postgres parameter", async () => {
+    process.env = { ...process.env, NODE_ENV: "dev" };
     mockRequest.session.userid = 999999;
     mockRequest.params.database = "Postgres";
     mockFindOne.mockReturnValue({
@@ -108,6 +113,7 @@ describe("Testing database router", () => {
     );
   });
   test("when database function is called with logged in user and Elasticsearch parameter", async () => {
+    process.env = { ...process.env, NODE_ENV: "dev" };
     mockRequest.session.userid = 999999;
     mockRequest.params.database = "Elasticsearch";
     mockFindOne.mockReturnValue({

--- a/src/routes/renderRoutes.test.js
+++ b/src/routes/renderRoutes.test.js
@@ -1,7 +1,8 @@
 jest.mock("../../sequelize/db");
 jest.mock("../../database/elasticsearch/elastic");
 jest.mock("../../database/postgres/pg");
-
+jest.mock("../../database/arango/arango");
+jest.mock("arangojs");
 const db = require("../../sequelize/db");
 const es = require("../../database/elasticsearch/elastic");
 const { database } = require("./renderRoutes");
@@ -28,10 +29,18 @@ describe("Testing database router", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+  test("when database function is called with non-logged in user and Arango parameter", async () => {
+    mockRequest.params.database = "Arango";
+    await database(mockRequest, mockResponse);
+    expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
+    expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
+      "https://arangodb.songz.dev/"
+    );
+  });
   test("when database function is called with non-logged in user and Postgres parameter", async () => {
     mockRequest.params.database = "Postgres";
     await database(mockRequest, mockResponse);
-    expect(mockResponse.render.mock.calls[0][1].username).toEqual(null);
+    expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
     expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
       "learndatabases.dev"
     );
@@ -39,9 +48,22 @@ describe("Testing database router", () => {
   test("when database function is called with non-logged in user and Elasticsearch parameter", async () => {
     mockRequest.params.database = "Elasticsearch";
     await database(mockRequest, mockResponse);
-    expect(mockResponse.render.mock.calls[0][1].username).toEqual(null);
+    expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
     expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
       "elastic.learndatabases.dev"
+    );
+  });
+  test("when database function is called with logged in user and Arango parameter", async () => {
+    mockRequest.session.userid = 999999;
+    mockRequest.params.database = "Arango";
+    mockFindOne.mockReturnValue({
+      username: "testuser",
+      dbPassword: "database",
+    });
+    await database(mockRequest, mockResponse);
+    expect(mockResponse.render.mock.calls[0][1].username).toEqual("testuser");
+    expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
+      "https://arangodb.songz.dev/"
     );
   });
   test("when database function is called with logged in user and Postgres parameter", async () => {

--- a/src/routes/renderRoutes.test.js
+++ b/src/routes/renderRoutes.test.js
@@ -4,7 +4,7 @@ jest.mock("../../database/postgres/pg");
 jest.mock("../../database/arango/arango");
 jest.mock("arangojs");
 const db = require("../../sequelize/db");
-
+const { database } = require("./renderRoutes");
 const mockFindOne = jest.fn();
 db.getModels = () => {
   return {
@@ -21,13 +21,18 @@ const mockRequest = {
   session: {},
 };
 
-const { database } = require("./renderRoutes");
-
 describe("Testing database router", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-
+  test("when database function is called with non-logged in user and Arango parameter", async () => {
+    mockRequest.params.database = "Arango";
+    await database(mockRequest, mockResponse);
+    expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
+    expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
+      "https://arangodb.songz.dev/"
+    );
+  });
   test("when database function is called with non-logged in user and Postgres parameter", async () => {
     mockRequest.params.database = "Postgres";
     await database(mockRequest, mockResponse);

--- a/src/routes/renderRoutes.test.js
+++ b/src/routes/renderRoutes.test.js
@@ -3,6 +3,7 @@ jest.mock("../../database/elasticsearch/elastic");
 jest.mock("../../database/postgres/pg");
 jest.mock("../../database/arango/arango");
 jest.mock("arangojs");
+require("dotenv").config();
 const db = require("../../sequelize/db");
 const { database } = require("./renderRoutes");
 const mockFindOne = jest.fn();
@@ -30,7 +31,7 @@ describe("Testing database router", () => {
     await database(mockRequest, mockResponse);
     expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
     expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
-      "https://arangodb.songz.dev/"
+      process.env.ARANGO_URL
     );
   });
   test("when database function is called with non-logged in user and Postgres parameter", async () => {
@@ -46,7 +47,7 @@ describe("Testing database router", () => {
     await database(mockRequest, mockResponse);
     expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
     expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
-      "elastic.learndatabases.dev"
+      process.env.ES_HOST
     );
   });
   test("when database function is called with logged in user and Arango parameter", async () => {
@@ -59,7 +60,7 @@ describe("Testing database router", () => {
     await database(mockRequest, mockResponse);
     expect(mockResponse.render.mock.calls[0][1].username).toEqual("testuser");
     expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
-      "https://arangodb.songz.dev/"
+      process.env.ARANGO_URL
     );
   });
   test("when database function is called with logged in user and Postgres parameter", async () => {
@@ -85,7 +86,7 @@ describe("Testing database router", () => {
     await database(mockRequest, mockResponse);
     expect(mockResponse.render.mock.calls[0][1].username).toEqual("testuser");
     expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
-      "elastic.learndatabases.dev"
+      process.env.ES_HOST
     );
   });
 });

--- a/src/routes/renderRoutes.test.js
+++ b/src/routes/renderRoutes.test.js
@@ -39,7 +39,7 @@ describe("Testing database router", () => {
     await database(mockRequest, mockResponse);
     expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
     expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
-      "learndatabases.dev"
+      process.env.HOST
     );
   });
   test("when database function is called with non-logged in user and Elasticsearch parameter", async () => {
@@ -73,7 +73,7 @@ describe("Testing database router", () => {
     await database(mockRequest, mockResponse);
     expect(mockResponse.render.mock.calls[0][1].username).toEqual("testuser");
     expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
-      "learndatabases.dev"
+      process.env.HOST
     );
   });
   test("when database function is called with logged in user and Elasticsearch parameter", async () => {

--- a/src/routes/renderRoutes.test.js
+++ b/src/routes/renderRoutes.test.js
@@ -21,10 +21,41 @@ const mockRequest = {
   params: {},
   session: {},
 };
-
 describe("Testing database router", () => {
+  const OLD_ENV = process.env;
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env = { ...OLD_ENV };
+  });
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+  test("should render correct CI hostname to front-end", async () => {
+    mockRequest.params.database = "Arango";
+    process.env = { ...process.env, NODE_ENV: "CI" };
+    await database(mockRequest, mockResponse);
+    expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
+    expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
+      "arangodb.learndatabases.dev"
+    );
+  });
+  test("should render correct CI hostname to frontend elasticsearch", async () => {
+    process.env = { ...process.env, NODE_ENV: "CI" };
+    mockRequest.params.database = "Elasticsearch";
+    await database(mockRequest, mockResponse);
+    expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
+    expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
+      "elastic.learndatabases.dev"
+    );
+  });
+  test("should render correct CI hostname to frontend postgres", async () => {
+    process.env = { ...process.env, NODE_ENV: "CI" };
+    mockRequest.params.database = "Postgres";
+    await database(mockRequest, mockResponse);
+    expect(mockResponse.render.mock.calls[0][1].username).toBeFalsy();
+    expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
+      "learndatabases.dev"
+    );
   });
   test("when database function is called with non-logged in user and Arango parameter", async () => {
     mockRequest.params.database = "Arango";

--- a/src/routes/renderRoutes.test.js
+++ b/src/routes/renderRoutes.test.js
@@ -4,9 +4,6 @@ jest.mock("../../database/postgres/pg");
 jest.mock("../../database/arango/arango");
 jest.mock("arangojs");
 const db = require("../../sequelize/db");
-const arango = require("../../database/arango/arango");
-const es = require("../../database/elasticsearch/elastic");
-const { database } = require("./renderRoutes");
 
 const mockFindOne = jest.fn();
 db.getModels = () => {
@@ -24,13 +21,13 @@ const mockRequest = {
   session: {},
 };
 
-es.checkAccount = jest.fn();
-arango.checkIfDatabaseExists = jest.fn();
+const { database } = require("./renderRoutes");
 
 describe("Testing database router", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
   test("when database function is called with non-logged in user and Postgres parameter", async () => {
     mockRequest.params.database = "Postgres";
     await database(mockRequest, mockResponse);

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -164,7 +164,7 @@ routes.createDatabase = async (req, res) => {
     return res.json({ ...user.dataValues, password: null });
   } catch (err) {
     logger.error("Error with creating database:", err);
-    res
+    return res
       .status(501)
       .json({ error: { message: "Database creation was not implemented" } });
   }

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -133,7 +133,7 @@ routes.userResetPassword = async (req, res) => {
     return res.json({ ...dataValues, password: null });
   } catch (err) {
     logger.error("user reset password error:", err);
-    res.status(500).json({
+    return res.status(500).json({
       error: { message: "Reset user password failed. Please try again" },
     });
   }

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -30,10 +30,10 @@ routes.resetPasswordEmail = async (req, res) => {
   try {
     const account = await sendPasswordResetEmail(userAccount);
     logger.info(`user reset password email sent to user ${id}`);
-    res.json({ ...account.dataValues, password: null });
+    return res.json({ ...account.dataValues, password: null });
   } catch (err) {
     logger.error(`Could not send email to user ${id}`);
-    res
+    return res
       .status(500)
       .json({ error: { message: "Email delivery failed. Please try again" } });
   }
@@ -55,7 +55,7 @@ routes.createUser = async (req, res) => {
       ? "This account already exists."
       : err.toString();
 
-    res.status(400).json({ error: { message } });
+    return res.status(400).json({ error: { message } });
   }
 };
 
@@ -87,7 +87,7 @@ routes.deleteUser = async (req, res) => {
     return res.json({ ...account.dataValues, password: null });
   } catch (err) {
     logger.error("Deleting user failed", id, err);
-    res
+    return res
       .status(500)
       .json({ error: { message: "Deleting user failed. Please try again" } });
   }
@@ -104,10 +104,10 @@ routes.loginUser = async (req, res) => {
     req.session.userid = id;
     req.session.email = email;
     logger.info("Logged in", email);
-    res.json({ ...dataValues, password: null });
+    return res.json({ ...dataValues, password: null });
   } catch (err) {
     logger.info(err);
-    res
+    return res
       .status(500)
       .json({ error: { message: "Login user failed. Please try again" } });
   }
@@ -118,7 +118,7 @@ routes.logoutUser = (req, res) => {
   req.session.email = "";
 
   logger.info("user logged out");
-  res.json({ message: `Logout succeeded` });
+  return res.json({ message: `Logout succeeded` });
 };
 
 routes.userResetPassword = async (req, res) => {
@@ -130,7 +130,7 @@ routes.userResetPassword = async (req, res) => {
     logger.info("User password reset for", email);
     req.session.userid = id;
     req.session.email = email;
-    res.json({ ...dataValues, password: null });
+    return res.json({ ...dataValues, password: null });
   } catch (err) {
     logger.error("user reset password error:", err);
     res.status(500).json({
@@ -140,9 +140,9 @@ routes.userResetPassword = async (req, res) => {
 };
 
 const createDatabaseAccount = {
-  Postgres: (user) => pgModule.userHasPgAccount(user),
-  Elasticsearch: (user) => es.createAccount(user),
-  Arango: (user) => arangoModule.createAccount(user),
+  Postgres: pgModule.userHasPgAccount,
+  Elasticsearch: es.createAccount,
+  Arango: arangoModule.createAccount,
 };
 
 routes.createDatabase = async (req, res) => {
@@ -161,7 +161,7 @@ routes.createDatabase = async (req, res) => {
       : await Accounts.findOne({ where: { id: userid } });
     !email && logger.info("Succeded creating anonymous user account", user.id);
     await createDatabaseAccount[database](user);
-    res.json({ ...user.dataValues, password: null });
+    return res.json({ ...user.dataValues, password: null });
   } catch (err) {
     logger.error("Error with creating database:", err);
     res

--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -862,14 +862,14 @@ exports[`test welcome page should render welcome page correctly 1`] = `
         <h4 class=\\"db-title\\">Elasticsearch</h4>
         <p class=\\"db-discription\\">A highly scalable full-text search analytics engine. It allows you to store, search and analyze big volumes of data quickly and in near real time.</p>
       </blockquote>
+      <blockquote id=\\"arango\\" class=\\"db-card umami--click--arango-button\\">
+        <h4 class=\\"db-title\\">Arango</h4>
+        <p class=\\"db-discription\\">A multi-model database. Whether you want to store data in tables or graphs is up to you!</p>
+      </blockquote>
       <blockquote id=\\"mongodb\\" class=\\"db-card darkenCards umami--click--mongodb-button\\">
         <h4 class=\\"db-title\\">MongoDB (coming next sprint!)</h4>
         <p class=\\"db-discription\\">An open source database management system using a document-oriented database model that supports various forms of data.<p>
 			</blockquote>
-      <blockquote id=\\"arango\\" class=\\"db-card umami--click--neo4j-button\\">
-        <h4 class=\\"db-title\\">Arango (coming next sprint!)</h4>
-        <p class=\\"db-discription\\">A multi-model database. Whether you want to store data in tables or graphs is up to you!</p>
-      </blockquote>
 
     <p style=\\"text-align:center;\\">Everything we do here is open source. Checkout our github
     <a href=\\"https://github.com/garageScript/databases\\" class=\\"umami--click--github-anchor\\">Here</a></p>

--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -1,5 +1,195 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`test welcome page should render arango page correctly 1`] = `
+"<!--views/partials/head.ejs-->
+<meta charset='UTF-8'>
+<!--CSS (load bootstrap from a CDN)-->
+<link rel=\\"stylesheet\\" href=\\"https://cdn.jsdelivr.net/npm/open-fonts@1.1.1/fonts/inter.min.css\\">
+<link rel=\\"stylesheet\\" href=\\"https://cdn.jsdelivr.net/npm/@exampledev/new.css@1.1.2/new.min.css\\">
+<link rel=\\"icon\\" type=\\"image/gif\\" href=\\"/database.gif\\">
+<style>
+    input {
+        text-align: center;
+        width: 400px;
+        height: 40px;
+        margin: 5px;
+    }
+    button {
+        width: 400px;
+        height: 40px;
+        margin: 10px;
+    }
+    .home {
+        cursor: pointer;
+    }
+    .card {
+        width: 450px;
+        margin: auto;
+    }
+    .card > * {
+        text-align: center;
+    }
+    .subtitle {
+        margin: 10px;
+    }
+    .body {
+        margin: 10px;
+    }
+</style>
+<html lang=\\"en\\">
+  <head>
+    <title>learndatabases.dev</title>
+  </head>
+  <header>
+    <h1 class=\\"home umami--click--home-button\\">Learn Databases</h1>
+    
+    
+      <p><a href=\\"/signin\\" class=\\"umami--click--login-button\\">Login</a> / <a href=\\"/signup\\" class=\\"umami--click--signup-button\\">Signup</a></p>
+    
+  </header>
+</html>
+<script>
+  const home = document.querySelector('.home')
+  home.addEventListener('click', () => {
+    return location.href = '/'
+  })
+
+  
+</script>
+
+<h3>Learn Arango</h3>
+<div id=\\"introduction\\"></div>
+<div id=\\"content\\"></div>
+<script src=\\"https://cdn.jsdelivr.net/npm/marked/marked.min.js\\"></script>
+<script
+  src=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/highlight.min.js\\"
+  integrity=\\"sha512-TDKKr+IvoqZnPzc3l35hdjpHD0m+b2EC2SrLEgKDRWpxf2rFCxemkgvJ5kfU48ip+Y+m2XVKyOCD85ybtlZDmw==\\"
+  crossorigin=\\"anonymous\\"
+></script>
+<link
+  rel=\\"stylesheet\\"
+  href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/styles/tomorrow.min.css\\"
+  integrity=\\"sha512-r3qr7vMdHYmWUzqC7l4H/W03ikAyiFIQld+B71yAmHhu7wcsnvm/adhikM+FzDxxK9ewznhCVnAm+yYZpPBnSg==\\"
+  crossorigin=\\"anonymous\\"
+/>
+<script>
+  const dbHost = \\"https://arangodb.songz.dev/\\";
+  const username = \\"\\";
+  const dbPassword = \\"\\";
+  const dbExists = \\"\\";
+  const database = \\"Arango\\";
+
+  const credentials = document.createElement(\\"pre\\");
+  const renderCredentials = (username, dbPassword) => {
+    const creds = \`host: \${dbHost}\\\\nusername: \${username}\\\\npassword: \${dbPassword}\\\\n\`;
+    /**
+     **** EACH TIME A DATABASE IS ADDED, ADD TO THE endingChoice OBJECT ****
+     * This is the only change you need to make if you are altering
+     * this file because another database has been implemented.
+     */
+    const endingChoice = {
+      Postgres: \`database: \${username}\`,
+      Elasticsearch: \`index: \${username}-*\`,
+      Arango: \`databaseName: \${username}\`,
+    };
+    credentials.innerHTML = \`<code>\${creds}\${endingChoice[database]}</code>\`;
+    introduction.append(credentials);
+  };
+
+  const content = document.getElementById(\\"content\\");
+  const renderContent = async (username, dbPassword) => {
+    const r = await fetch(\`/lessons/\${database}.md\`).then((r) => r.text());
+    marked.setOptions({
+      highlight: function (code) {
+        return hljs.highlightAuto(code).value;
+      },
+    });
+    const markedHTML = marked(r);
+    const markedHTMLwithUserData = markedHTML
+      .replace(/@username/gi, username)
+      .replace(/@dbPassword/gi, dbPassword);
+    content.innerHTML = markedHTMLwithUserData;
+  };
+
+  let disabled;
+  const createDb = async () => {
+    if (disabled) return;
+    disabled = true;
+    createDb_button.classList.add(\\"disabled\\");
+    createDb_button.innerText = \\"Creating...\\";
+
+    const res = await fetch(\`/api/createDatabase/\${database}\`, {
+      method: \\"POST\\",
+    }).then((r) => r.json());
+    const { error, username, dbPassword, email } = res;
+    if (error) {
+      alert(error.message);
+      disabled = false;
+      createDb_button.classList.remove(\\"disabled\\");
+      createDb_button.innerText = \\"Create my database\\";
+      return;
+    }
+    alert(
+      email
+        ? \\"Your database has been successfully created!\\"
+        : \\"Your temporary database has been successfully created!\\\\r\\\\nSince credentials are provided only once, please keep the information somewhere safe.\\"
+    );
+    createDb_button.style.opacity = 0;
+    setTimeout(() => {
+      createDb_button.innerText = \\"Complete!\\";
+      createDb_button.style.background = \\"rgb(10, 170, 75)\\";
+      createDb_button.style.opacity = 1;
+      setTimeout(() => {
+        renderCredentials(username, dbPassword);
+        renderContent(username, dbPassword);
+      }, 200);
+    }, 200);
+  };
+
+  const createDb_button = document.createElement(\\"button\\");
+  createDb_button.id = \\"createDb\\";
+  createDb_button.innerText = \\"Create my database\\";
+  createDb_button.addEventListener(\\"click\\", createDb);
+
+  (function setIntroduction() {
+    const vowelsTable = [\\"A\\", \\"E\\", \\"I\\", \\"O\\", \\"U\\"].reduce((acc, vowel) => {
+      acc[vowel] = true;
+      return acc;
+    }, {});
+    const a = \`a\${vowelsTable[database[0]] ? \\"n\\" : \\"\\"}\`;
+    const introduction = document.getElementById(\\"introduction\\");
+    const messageOpening = \`<p>In this module, you can learn how to use \${database}. \`;
+    if (!username || !dbExists) {
+      const tense = !username ? \\"temporary \\" : \\"\\";
+      const messageMiddle = \`Don't have \${database} installed on your local machine yet? Fear not! We can make \${a} \${database} database for you. Simply click on the button below to create your \${tense}database. Credentials for your database will appear after it is done being created.</p>\`;
+      const messageEnding = !username
+        ? \`<p>Temporary database credentials will expire in 5 days. If you want, you can sign up with us and get a non-expiring \${database} database!</p>\`
+        : \\"\\";
+      introduction.innerHTML = \`\${messageOpening}\${messageMiddle}\${messageEnding}\`;
+      introduction.append(createDb_button);
+      return renderContent(\\"username\\", \\"dbPassword\\");
+    }
+    introduction.innerHTML = \`\${messageOpening}You have already created \${a} \${database} database on our server. Here are the credentials for your database.</p>\`;
+    renderCredentials(username, dbPassword);
+    renderContent(username, dbPassword);
+  })();
+</script>
+<style>
+  #createDb {
+    display: block;
+    margin: auto;
+    margin-top: 26px;
+    margin-bottom: 26px;
+    transition: 0.2s;
+  }
+
+  #createDb.disabled {
+    cursor: default;
+  }
+</style>
+"
+`;
+
 exports[`test welcome page should render elasticsearch page correctly 1`] = `
 "<!--views/partials/head.ejs-->
 <meta charset='UTF-8'>
@@ -76,7 +266,7 @@ exports[`test welcome page should render elasticsearch page correctly 1`] = `
   const dbHost = \\"https://elastic.learndatabases.dev\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
-  const dbExists = \\"false\\";
+  const dbExists = \\"\\";
   const database = \\"Elasticsearch\\";
 
   const credentials = document.createElement(\\"pre\\");
@@ -266,7 +456,7 @@ exports[`test welcome page should render postgres page correctly 1`] = `
   const dbHost = \\"104.168.169.204\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
-  const dbExists = \\"false\\";
+  const dbExists = \\"\\";
   const database = \\"Postgres\\";
 
   const credentials = document.createElement(\\"pre\\");

--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -73,7 +73,7 @@ exports[`test welcome page should render elasticsearch page correctly 1`] = `
   crossorigin=\\"anonymous\\"
 />
 <script>
-  const dbHost = \\"elastic.learndatabases.dev\\";
+  const dbHost = \\"https://elastic.learndatabases.dev\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
   const dbExists = \\"false\\";

--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -263,7 +263,7 @@ exports[`test welcome page should render postgres page correctly 1`] = `
   crossorigin=\\"anonymous\\"
 />
 <script>
-  const dbHost = \\"learndatabases.dev\\";
+  const dbHost = \\"104.168.169.204\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
   const dbExists = \\"false\\";

--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -152,15 +152,12 @@ exports[`test welcome page should render elasticsearch page correctly 1`] = `
   createDb_button.addEventListener(\\"click\\", createDb);
 
   (function setIntroduction() {
-    const vowelsTable = {
-      A: true,
-      E: true,
-      I: true,
-      O: true,
-      U: true,
-    };
-    const introduction = document.getElementById(\\"introduction\\");
+    const vowelsTable = [\\"A\\", \\"E\\", \\"I\\", \\"O\\", \\"U\\"].reduce((acc, vowel) => {
+      acc[vowel] = true;
+      return acc;
+    }, {});
     const a = \`a\${vowelsTable[database[0]] ? \\"n\\" : \\"\\"}\`;
+    const introduction = document.getElementById(\\"introduction\\");
     const messageOpening = \`<p>In this module, you can learn how to use \${database}. \`;
     if (!username || !dbExists) {
       const tense = !username ? \\"temporary \\" : \\"\\";
@@ -345,15 +342,12 @@ exports[`test welcome page should render postgres page correctly 1`] = `
   createDb_button.addEventListener(\\"click\\", createDb);
 
   (function setIntroduction() {
-    const vowelsTable = {
-      A: true,
-      E: true,
-      I: true,
-      O: true,
-      U: true,
-    };
-    const introduction = document.getElementById(\\"introduction\\");
+    const vowelsTable = [\\"A\\", \\"E\\", \\"I\\", \\"O\\", \\"U\\"].reduce((acc, vowel) => {
+      acc[vowel] = true;
+      return acc;
+    }, {});
     const a = \`a\${vowelsTable[database[0]] ? \\"n\\" : \\"\\"}\`;
+    const introduction = document.getElementById(\\"introduction\\");
     const messageOpening = \`<p>In this module, you can learn how to use \${database}. \`;
     if (!username || !dbExists) {
       const tense = !username ? \\"temporary \\" : \\"\\";

--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -73,7 +73,7 @@ exports[`test welcome page should render arango page correctly 1`] = `
   crossorigin=\\"anonymous\\"
 />
 <script>
-  const dbHost = \\"https://arangodb.songz.dev/\\";
+  const dbHost = \\"arangodb.learndatabases.dev\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
   const dbExists = \\"\\";
@@ -263,7 +263,7 @@ exports[`test welcome page should render elasticsearch page correctly 1`] = `
   crossorigin=\\"anonymous\\"
 />
 <script>
-  const dbHost = \\"https://elastic.learndatabases.dev\\";
+  const dbHost = \\"elastic.learndatabases.dev\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
   const dbExists = \\"\\";
@@ -453,7 +453,7 @@ exports[`test welcome page should render postgres page correctly 1`] = `
   crossorigin=\\"anonymous\\"
 />
 <script>
-  const dbHost = \\"104.168.169.204\\";
+  const dbHost = \\"learndatabases.dev\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
   const dbExists = \\"\\";

--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -58,116 +58,125 @@ exports[`test welcome page should render elasticsearch page correctly 1`] = `
 </script>
 
 <h3>Learn Elasticsearch</h3>
-<div id=\\"introduction\\">
-</div>
+<div id=\\"introduction\\"></div>
 <div id=\\"content\\"></div>
 <script src=\\"https://cdn.jsdelivr.net/npm/marked/marked.min.js\\"></script>
-<script src=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/highlight.min.js\\"
+<script
+  src=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/highlight.min.js\\"
   integrity=\\"sha512-TDKKr+IvoqZnPzc3l35hdjpHD0m+b2EC2SrLEgKDRWpxf2rFCxemkgvJ5kfU48ip+Y+m2XVKyOCD85ybtlZDmw==\\"
-  crossorigin=\\"anonymous\\"></script>
-<link rel=\\"stylesheet\\" href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/styles/tomorrow.min.css\\"
+  crossorigin=\\"anonymous\\"
+></script>
+<link
+  rel=\\"stylesheet\\"
+  href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/styles/tomorrow.min.css\\"
   integrity=\\"sha512-r3qr7vMdHYmWUzqC7l4H/W03ikAyiFIQld+B71yAmHhu7wcsnvm/adhikM+FzDxxK9ewznhCVnAm+yYZpPBnSg==\\"
-  crossorigin=\\"anonymous\\" />
+  crossorigin=\\"anonymous\\"
+/>
 <script>
-  const dbHost = \\"elastic.learndatabases.dev\\"
-  const username = \\"\\"
-  const dbPassword = \\"\\"
-  const dbExists = false
-  const database = \\"Elasticsearch\\"
+  const dbHost = \\"elastic.learndatabases.dev\\";
+  const username = \\"\\";
+  const dbPassword = \\"\\";
+  const dbExists = \\"false\\";
+  const database = \\"Elasticsearch\\";
 
-  const credentials = document.createElement(\\"pre\\")
+  const credentials = document.createElement(\\"pre\\");
   const renderCredentials = (username, dbPassword) => {
-    if (database === \\"Postgres\\") {
-      credentials.innerHTML = \`<code>host: \${dbHost}
-username: \${username}
-password: \${dbPassword}
-database: \${username}</code>\`
-    } else if (database === \\"Elasticsearch\\") {
-      credentials.innerHTML = \`<code>host: \${dbHost}
-username: \${username}
-password: \${dbPassword}
-index: \${username}-*</code>\`
-    } else {
-      credentials.innerHTML = \\"\\"
+    const creds = \`host: \${dbHost}\\\\nusername: \${username}\\\\npassword: \${dbPassword}\\\\n\`;
+    /**
+     **** EACH TIME A DATABASE IS ADDED, ADD TO THE endingChoice OBJECT ****
+     * This is the only change you need to make if you are altering
+     * this file because another database has been implemented.
+     */
+    const endingChoice = {
+      Postgres: \`database: \${username}\`,
+      Elasticsearch: \`index: \${username}-*\`,
+      Arango: \`databaseName: \${username}\`,
+    };
+    credentials.innerHTML = \`<code>\${creds}\${endingChoice[database]}</code>\`;
+    introduction.append(credentials);
+  };
+
+  const content = document.getElementById(\\"content\\");
+  const renderContent = async (username, dbPassword) => {
+    const r = await fetch(\`/lessons/\${database}.md\`).then((r) => r.text());
+    marked.setOptions({
+      highlight: function (code) {
+        return hljs.highlightAuto(code).value;
+      },
+    });
+    const markedHTML = marked(r);
+    const markedHTMLwithUserData = markedHTML
+      .replace(/@username/gi, username)
+      .replace(/@dbPassword/gi, dbPassword);
+    content.innerHTML = markedHTMLwithUserData;
+  };
+
+  let disabled;
+  const createDb = async () => {
+    if (disabled) return;
+    disabled = true;
+    createDb_button.classList.add(\\"disabled\\");
+    createDb_button.innerText = \\"Creating...\\";
+
+    const res = await fetch(\`/api/createDatabase/\${database}\`, {
+      method: \\"POST\\",
+    }).then((r) => r.json());
+    const { error, username, dbPassword, email } = res;
+    if (error) {
+      alert(error.message);
+      disabled = false;
+      createDb_button.classList.remove(\\"disabled\\");
+      createDb_button.innerText = \\"Create my database\\";
+      return;
     }
-    introduction.append(credentials)
-  }
+    alert(
+      email
+        ? \\"Your database has been successfully created!\\"
+        : \\"Your temporary database has been successfully created!\\\\r\\\\nSince credentials are provided only once, please keep the information somewhere safe.\\"
+    );
+    createDb_button.style.opacity = 0;
+    setTimeout(() => {
+      createDb_button.innerText = \\"Complete!\\";
+      createDb_button.style.background = \\"rgb(10, 170, 75)\\";
+      createDb_button.style.opacity = 1;
+      setTimeout(() => {
+        renderCredentials(username, dbPassword);
+        renderContent(username, dbPassword);
+      }, 200);
+    }, 200);
+  };
 
-  const content = document.getElementById(\\"content\\")
-  const renderContent = (username, dbPassword) => {
-    fetch(\`/lessons/\${database}.md\`).then(r => r.text()).then((r) => {
-      marked.setOptions({
-        highlight: function (code) {
-          return hljs.highlightAuto(code).value
-        }
-      })
-      const markedHTML = marked(r)
-      const markedHTMLwithUserData = markedHTML.replace(/@username/gi, username).replace(/@dbPassword/gi, dbPassword)
-      content.innerHTML = markedHTMLwithUserData
-    })
-  }
-  
-  let disabled
-  const createDb = () => {
-    if (disabled) return
-    disabled = true
-    createDb_button.classList.add(\\"disabled\\")
-    createDb_button.innerText = \\"Creating...\\"
-    fetch(\`/api/createDatabase/\${database}\`, { method: \\"POST\\" }).then(r => r.json()).then((r) => {
-      if (r.error) {
-        alert(r.error.message)
-        disabled = false
-        createDb_button.classList.remove(\\"disabled\\")
-        createDb_button.innerText = \\"Create my database\\"
-      } else {
-        if (r.email) {
-          alert(\\"Your database is successfully created!\\")
-        } else {
-          alert(\\"Your temporary database is successfully created!\\\\r\\\\nSince credentials are provided only once, please keep the information somewhere safe.\\")
-        }
-        createDb_button.style.opacity = 0
-        setTimeout(() => {
-          createDb_button.innerText = \\"Complete!\\"
-          createDb_button.style.background = \\"rgb(10, 170, 75)\\"
-          createDb_button.style.opacity = 1
-          setTimeout(() => {
-            renderCredentials(r.username, r.dbPassword)
-            renderContent(r.username, r.dbPassword)
-          }, 200)
-        }, 200)
-      }
-    })
-  }
+  const createDb_button = document.createElement(\\"button\\");
+  createDb_button.id = \\"createDb\\";
+  createDb_button.innerText = \\"Create my database\\";
+  createDb_button.addEventListener(\\"click\\", createDb);
 
-  const createDb_button = document.createElement(\\"button\\")
-  createDb_button.id = \\"createDb\\"
-  createDb_button.innerText = \\"Create my database\\"
-  createDb_button.addEventListener(\\"click\\", createDb)
-  
-  const introduction = document.getElementById(\\"introduction\\")
-  if (!username) {
-    introduction.innerHTML = \`
-      <p>In this module, you can learn how to use \${database}. Don't have \${database} installed on your local machine yet? Fear not! We can make a \${database} database for you. Simply click on the button below to create your temporary \${database} database. Credentials for your database will appear after it is done being created.</p>
-      <p>Temporary database credentials will expire in 5 days. If you want, you can sign up with us and get a non-expiring Postgres database!</p>
-    \`
-    introduction.append(createDb_button)
-    renderContent(\\"username\\", \\"dbPassword\\")
-  } else if (!dbExists) {
-    introduction.innerHTML = \`
-      <p>In this module, you can learn how to use \${database}. Don't have \${database} installed on your local machine yet? Fear not! We can make an \${database} database for you. Simply click on the button below to create your \${database} database. Credentials for your database will appear after it is done being created.</p>
-    \`
-    introduction.append(createDb_button)
-    renderContent(\\"username\\", \\"dbPassword\\")
-  } else {
-    introduction.innerHTML = \`
-<p>In this module, you can learn how to use \${database}. You have already created an \${database} database on our server. Here are the credentials for your database.</p>
-    \`
-    renderCredentials(username, dbPassword)
-    renderContent(username, dbPassword)
-  }
-
+  (function setIntroduction() {
+    const vowelsTable = {
+      A: true,
+      E: true,
+      I: true,
+      O: true,
+      U: true,
+    };
+    const introduction = document.getElementById(\\"introduction\\");
+    const a = \`a\${vowelsTable[database[0]] ? \\"n\\" : \\"\\"}\`;
+    const messageOpening = \`<p>In this module, you can learn how to use \${database}. \`;
+    if (!username || !dbExists) {
+      const tense = !username ? \\"temporary \\" : \\"\\";
+      const messageMiddle = \`Don't have \${database} installed on your local machine yet? Fear not! We can make \${a} \${database} database for you. Simply click on the button below to create your \${tense}database. Credentials for your database will appear after it is done being created.</p>\`;
+      const messageEnding = !username
+        ? \`<p>Temporary database credentials will expire in 5 days. If you want, you can sign up with us and get a non-expiring \${database} database!</p>\`
+        : \\"\\";
+      introduction.innerHTML = \`\${messageOpening}\${messageMiddle}\${messageEnding}\`;
+      introduction.append(createDb_button);
+      return renderContent(\\"username\\", \\"dbPassword\\");
+    }
+    introduction.innerHTML = \`\${messageOpening}You have already created \${a} \${database} database on our server. Here are the credentials for your database.</p>\`;
+    renderCredentials(username, dbPassword);
+    renderContent(username, dbPassword);
+  })();
 </script>
-
 <style>
   #createDb {
     display: block;
@@ -242,116 +251,125 @@ exports[`test welcome page should render postgres page correctly 1`] = `
 </script>
 
 <h3>Learn Postgres</h3>
-<div id=\\"introduction\\">
-</div>
+<div id=\\"introduction\\"></div>
 <div id=\\"content\\"></div>
 <script src=\\"https://cdn.jsdelivr.net/npm/marked/marked.min.js\\"></script>
-<script src=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/highlight.min.js\\"
+<script
+  src=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/highlight.min.js\\"
   integrity=\\"sha512-TDKKr+IvoqZnPzc3l35hdjpHD0m+b2EC2SrLEgKDRWpxf2rFCxemkgvJ5kfU48ip+Y+m2XVKyOCD85ybtlZDmw==\\"
-  crossorigin=\\"anonymous\\"></script>
-<link rel=\\"stylesheet\\" href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/styles/tomorrow.min.css\\"
+  crossorigin=\\"anonymous\\"
+></script>
+<link
+  rel=\\"stylesheet\\"
+  href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/styles/tomorrow.min.css\\"
   integrity=\\"sha512-r3qr7vMdHYmWUzqC7l4H/W03ikAyiFIQld+B71yAmHhu7wcsnvm/adhikM+FzDxxK9ewznhCVnAm+yYZpPBnSg==\\"
-  crossorigin=\\"anonymous\\" />
+  crossorigin=\\"anonymous\\"
+/>
 <script>
-  const dbHost = \\"learndatabases.dev\\"
-  const username = \\"\\"
-  const dbPassword = \\"\\"
-  const dbExists = false
-  const database = \\"Postgres\\"
+  const dbHost = \\"learndatabases.dev\\";
+  const username = \\"\\";
+  const dbPassword = \\"\\";
+  const dbExists = \\"false\\";
+  const database = \\"Postgres\\";
 
-  const credentials = document.createElement(\\"pre\\")
+  const credentials = document.createElement(\\"pre\\");
   const renderCredentials = (username, dbPassword) => {
-    if (database === \\"Postgres\\") {
-      credentials.innerHTML = \`<code>host: \${dbHost}
-username: \${username}
-password: \${dbPassword}
-database: \${username}</code>\`
-    } else if (database === \\"Elasticsearch\\") {
-      credentials.innerHTML = \`<code>host: \${dbHost}
-username: \${username}
-password: \${dbPassword}
-index: \${username}-*</code>\`
-    } else {
-      credentials.innerHTML = \\"\\"
+    const creds = \`host: \${dbHost}\\\\nusername: \${username}\\\\npassword: \${dbPassword}\\\\n\`;
+    /**
+     **** EACH TIME A DATABASE IS ADDED, ADD TO THE endingChoice OBJECT ****
+     * This is the only change you need to make if you are altering
+     * this file because another database has been implemented.
+     */
+    const endingChoice = {
+      Postgres: \`database: \${username}\`,
+      Elasticsearch: \`index: \${username}-*\`,
+      Arango: \`databaseName: \${username}\`,
+    };
+    credentials.innerHTML = \`<code>\${creds}\${endingChoice[database]}</code>\`;
+    introduction.append(credentials);
+  };
+
+  const content = document.getElementById(\\"content\\");
+  const renderContent = async (username, dbPassword) => {
+    const r = await fetch(\`/lessons/\${database}.md\`).then((r) => r.text());
+    marked.setOptions({
+      highlight: function (code) {
+        return hljs.highlightAuto(code).value;
+      },
+    });
+    const markedHTML = marked(r);
+    const markedHTMLwithUserData = markedHTML
+      .replace(/@username/gi, username)
+      .replace(/@dbPassword/gi, dbPassword);
+    content.innerHTML = markedHTMLwithUserData;
+  };
+
+  let disabled;
+  const createDb = async () => {
+    if (disabled) return;
+    disabled = true;
+    createDb_button.classList.add(\\"disabled\\");
+    createDb_button.innerText = \\"Creating...\\";
+
+    const res = await fetch(\`/api/createDatabase/\${database}\`, {
+      method: \\"POST\\",
+    }).then((r) => r.json());
+    const { error, username, dbPassword, email } = res;
+    if (error) {
+      alert(error.message);
+      disabled = false;
+      createDb_button.classList.remove(\\"disabled\\");
+      createDb_button.innerText = \\"Create my database\\";
+      return;
     }
-    introduction.append(credentials)
-  }
+    alert(
+      email
+        ? \\"Your database has been successfully created!\\"
+        : \\"Your temporary database has been successfully created!\\\\r\\\\nSince credentials are provided only once, please keep the information somewhere safe.\\"
+    );
+    createDb_button.style.opacity = 0;
+    setTimeout(() => {
+      createDb_button.innerText = \\"Complete!\\";
+      createDb_button.style.background = \\"rgb(10, 170, 75)\\";
+      createDb_button.style.opacity = 1;
+      setTimeout(() => {
+        renderCredentials(username, dbPassword);
+        renderContent(username, dbPassword);
+      }, 200);
+    }, 200);
+  };
 
-  const content = document.getElementById(\\"content\\")
-  const renderContent = (username, dbPassword) => {
-    fetch(\`/lessons/\${database}.md\`).then(r => r.text()).then((r) => {
-      marked.setOptions({
-        highlight: function (code) {
-          return hljs.highlightAuto(code).value
-        }
-      })
-      const markedHTML = marked(r)
-      const markedHTMLwithUserData = markedHTML.replace(/@username/gi, username).replace(/@dbPassword/gi, dbPassword)
-      content.innerHTML = markedHTMLwithUserData
-    })
-  }
-  
-  let disabled
-  const createDb = () => {
-    if (disabled) return
-    disabled = true
-    createDb_button.classList.add(\\"disabled\\")
-    createDb_button.innerText = \\"Creating...\\"
-    fetch(\`/api/createDatabase/\${database}\`, { method: \\"POST\\" }).then(r => r.json()).then((r) => {
-      if (r.error) {
-        alert(r.error.message)
-        disabled = false
-        createDb_button.classList.remove(\\"disabled\\")
-        createDb_button.innerText = \\"Create my database\\"
-      } else {
-        if (r.email) {
-          alert(\\"Your database is successfully created!\\")
-        } else {
-          alert(\\"Your temporary database is successfully created!\\\\r\\\\nSince credentials are provided only once, please keep the information somewhere safe.\\")
-        }
-        createDb_button.style.opacity = 0
-        setTimeout(() => {
-          createDb_button.innerText = \\"Complete!\\"
-          createDb_button.style.background = \\"rgb(10, 170, 75)\\"
-          createDb_button.style.opacity = 1
-          setTimeout(() => {
-            renderCredentials(r.username, r.dbPassword)
-            renderContent(r.username, r.dbPassword)
-          }, 200)
-        }, 200)
-      }
-    })
-  }
+  const createDb_button = document.createElement(\\"button\\");
+  createDb_button.id = \\"createDb\\";
+  createDb_button.innerText = \\"Create my database\\";
+  createDb_button.addEventListener(\\"click\\", createDb);
 
-  const createDb_button = document.createElement(\\"button\\")
-  createDb_button.id = \\"createDb\\"
-  createDb_button.innerText = \\"Create my database\\"
-  createDb_button.addEventListener(\\"click\\", createDb)
-  
-  const introduction = document.getElementById(\\"introduction\\")
-  if (!username) {
-    introduction.innerHTML = \`
-      <p>In this module, you can learn how to use \${database}. Don't have \${database} installed on your local machine yet? Fear not! We can make a \${database} database for you. Simply click on the button below to create your temporary \${database} database. Credentials for your database will appear after it is done being created.</p>
-      <p>Temporary database credentials will expire in 5 days. If you want, you can sign up with us and get a non-expiring Postgres database!</p>
-    \`
-    introduction.append(createDb_button)
-    renderContent(\\"username\\", \\"dbPassword\\")
-  } else if (!dbExists) {
-    introduction.innerHTML = \`
-      <p>In this module, you can learn how to use \${database}. Don't have \${database} installed on your local machine yet? Fear not! We can make an \${database} database for you. Simply click on the button below to create your \${database} database. Credentials for your database will appear after it is done being created.</p>
-    \`
-    introduction.append(createDb_button)
-    renderContent(\\"username\\", \\"dbPassword\\")
-  } else {
-    introduction.innerHTML = \`
-<p>In this module, you can learn how to use \${database}. You have already created an \${database} database on our server. Here are the credentials for your database.</p>
-    \`
-    renderCredentials(username, dbPassword)
-    renderContent(username, dbPassword)
-  }
-
+  (function setIntroduction() {
+    const vowelsTable = {
+      A: true,
+      E: true,
+      I: true,
+      O: true,
+      U: true,
+    };
+    const introduction = document.getElementById(\\"introduction\\");
+    const a = \`a\${vowelsTable[database[0]] ? \\"n\\" : \\"\\"}\`;
+    const messageOpening = \`<p>In this module, you can learn how to use \${database}. \`;
+    if (!username || !dbExists) {
+      const tense = !username ? \\"temporary \\" : \\"\\";
+      const messageMiddle = \`Don't have \${database} installed on your local machine yet? Fear not! We can make \${a} \${database} database for you. Simply click on the button below to create your \${tense}database. Credentials for your database will appear after it is done being created.</p>\`;
+      const messageEnding = !username
+        ? \`<p>Temporary database credentials will expire in 5 days. If you want, you can sign up with us and get a non-expiring \${database} database!</p>\`
+        : \\"\\";
+      introduction.innerHTML = \`\${messageOpening}\${messageMiddle}\${messageEnding}\`;
+      introduction.append(createDb_button);
+      return renderContent(\\"username\\", \\"dbPassword\\");
+    }
+    introduction.innerHTML = \`\${messageOpening}You have already created \${a} \${database} database on our server. Here are the credentials for your database.</p>\`;
+    renderCredentials(username, dbPassword);
+    renderContent(username, dbPassword);
+  })();
 </script>
-
 <style>
   #createDb {
     display: block;
@@ -854,9 +872,9 @@ exports[`test welcome page should render welcome page correctly 1`] = `
         <h4 class=\\"db-title\\">MongoDB (coming next sprint!)</h4>
         <p class=\\"db-discription\\">An open source database management system using a document-oriented database model that supports various forms of data.<p>
 			</blockquote>
-      <blockquote id=\\"neo4j\\" class=\\"db-card darkenCards umami--click--neo4j-button\\">
-        <h4 class=\\"db-title\\">Neo4j (coming next sprint!)</h4>
-        <p class=\\"db-discription\\">A graph database management system that is the most popular graph database and the 22nd most popular database overall.</p>
+      <blockquote id=\\"arango\\" class=\\"db-card umami--click--neo4j-button\\">
+        <h4 class=\\"db-title\\">Arango (coming next sprint!)</h4>
+        <p class=\\"db-discription\\">A multi-model database. Whether you want to store data in tables or graphs is up to you!</p>
       </blockquote>
 
     <p style=\\"text-align:center;\\">Everything we do here is open source. Checkout our github
@@ -908,14 +926,12 @@ exports[`test welcome page should render welcome page correctly 1`] = `
         location.href = '/tutorial/Elasticsearch'
       }, 10)
     })
-		/*
-    document.getElementById('mongodb').addEventListener('click', () => {
-      location.href = '/mongodb'
-    })
-    document.getElementById('neo4j').addEventListener('click', () => {
-      location.href = '/neo4j'
+    // document.getElementById('mongodb').addEventListener('click', () => {
+    //   location.href = '/mongodb'
+    // })
+    document.getElementById('arango').addEventListener('click', () => {
+      location.href = '/tutorial/Arango'
 		})
-		*/
   </script>
 
   <script async defer data-website-id=\\"d367293a-0e30-4ae1-bdce-3651e1b64909\\" src=\\"https://analytics.learndatabases.dev/umami.js\\"></script>

--- a/tests/integration/welcome.test.js
+++ b/tests/integration/welcome.test.js
@@ -1,6 +1,5 @@
-jest.setTimeout(10000);
+jest.setTimeout(1000000);
 
-const session = require("express-session");
 const { startServer, stopServer } = require("../../src/server");
 const fetch = require("node-fetch");
 require("dotenv").config();
@@ -57,6 +56,13 @@ describe("test welcome page", () => {
 
   test("should render elasticsearch page correctly", async () => {
     const result = await fetch(baseUrl + "tutorial/Elasticsearch").then((r) =>
+      r.text()
+    );
+    expect(result).toMatchSnapshot();
+	});
+
+  test("should render arango page correctly", async () => {
+    const result = await fetch(baseUrl + "tutorial/Arango").then((r) =>
       r.text()
     );
     expect(result).toMatchSnapshot();

--- a/tests/integration/welcome.test.js
+++ b/tests/integration/welcome.test.js
@@ -7,35 +7,42 @@ require("dotenv").config();
 describe("test welcome page", () => {
   const testPort = process.env.TEST_PORT || 20200;
   const baseUrl = `http://localhost:${testPort}/`;
-
-  beforeAll(async () => {
+  const OLD_ENV = process.env;
+  beforeEach(async () => {
     await startServer(testPort);
+    process.env = { ...OLD_ENV };
   });
-  afterAll(async () => {
+  afterEach(async () => {
+    process.env = OLD_ENV;
     await stopServer();
   });
 
   test("should render welcome page correctly", async () => {
+    process.env = { ...process.env, NODE_ENV: "CI" };
     const result = await fetch(baseUrl).then((r) => r.text());
     expect(result).toMatchSnapshot();
   });
 
   test("should render setDBpassword page correctly", async () => {
+    process.env = { ...process.env, NODE_ENV: "dev" };
     const result = await fetch(baseUrl + "setDBpassword").then((r) => r.text());
     expect(result).toMatchSnapshot();
   });
 
   test("should render sign in page correctly", async () => {
+    process.env = { ...process.env, NODE_ENV: "dev" };
     const result = await fetch(baseUrl + "signin").then((r) => r.text());
     expect(result).toMatchSnapshot();
   });
 
   test("should render sign up page correctly", async () => {
+    process.env = { ...process.env, NODE_ENV: "dev" };
     const result = await fetch(baseUrl + "signup").then((r) => r.text());
     expect(result).toMatchSnapshot();
   });
 
   test("should render setPassword page correctly", async () => {
+    process.env = { ...process.env, NODE_ENV: "dev" };
     const result = await fetch(baseUrl + "setPassword/token").then((r) =>
       r.text()
     );
@@ -43,11 +50,13 @@ describe("test welcome page", () => {
   });
 
   test("should render resetPassword page correctly", async () => {
+    process.env = { ...process.env, NODE_ENV: "dev" };
     const result = await fetch(baseUrl + "resetPassword").then((r) => r.text());
     expect(result).toMatchSnapshot();
   });
 
   test("should render postgres page correctly", async () => {
+    process.env = { ...process.env, NODE_ENV: "CI" };
     const result = await fetch(baseUrl + "tutorial/Postgres").then((r) =>
       r.text()
     );
@@ -55,13 +64,15 @@ describe("test welcome page", () => {
   });
 
   test("should render elasticsearch page correctly", async () => {
+    process.env = { ...process.env, NODE_ENV: "CI" };
     const result = await fetch(baseUrl + "tutorial/Elasticsearch").then((r) =>
       r.text()
     );
     expect(result).toMatchSnapshot();
-	});
+  });
 
   test("should render arango page correctly", async () => {
+    process.env = { ...process.env, NODE_ENV: "CI" };
     const result = await fetch(baseUrl + "tutorial/Arango").then((r) =>
       r.text()
     );

--- a/views/tutorial.ejs
+++ b/views/tutorial.ejs
@@ -94,15 +94,12 @@
   createDb_button.addEventListener("click", createDb);
 
   (function setIntroduction() {
-    const vowelsTable = {
-      A: true,
-      E: true,
-      I: true,
-      O: true,
-      U: true,
-    };
-    const introduction = document.getElementById("introduction");
+    const vowelsTable = ["A", "E", "I", "O", "U"].reduce((acc, vowel) => {
+      acc[vowel] = true;
+      return acc;
+    }, {});
     const a = `a${vowelsTable[database[0]] ? "n" : ""}`;
+    const introduction = document.getElementById("introduction");
     const messageOpening = `<p>In this module, you can learn how to use ${database}. `;
     if (!username || !dbExists) {
       const tense = !username ? "temporary " : "";

--- a/views/tutorial.ejs
+++ b/views/tutorial.ejs
@@ -1,115 +1,124 @@
 <%- include("./partials/head") %>
 <h3>Learn <%= database %></h3>
-<div id="introduction">
-</div>
+<div id="introduction"></div>
 <div id="content"></div>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/highlight.min.js"
+<script
+  src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/highlight.min.js"
   integrity="sha512-TDKKr+IvoqZnPzc3l35hdjpHD0m+b2EC2SrLEgKDRWpxf2rFCxemkgvJ5kfU48ip+Y+m2XVKyOCD85ybtlZDmw=="
-  crossorigin="anonymous"></script>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/styles/tomorrow.min.css"
+  crossorigin="anonymous"
+></script>
+<link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/styles/tomorrow.min.css"
   integrity="sha512-r3qr7vMdHYmWUzqC7l4H/W03ikAyiFIQld+B71yAmHhu7wcsnvm/adhikM+FzDxxK9ewznhCVnAm+yYZpPBnSg=="
-  crossorigin="anonymous" />
+  crossorigin="anonymous"
+/>
 <script>
-  const dbHost = "<%= dbHost %>"
-  const username = "<%= username %>"
-  const dbPassword = "<%= dbPassword %>"
-  const dbExists = <%= dbExists %>
-  const database = "<%= database %>"
+  const dbHost = "<%= dbHost %>";
+  const username = "<%= username %>";
+  const dbPassword = "<%= dbPassword %>";
+  const dbExists = "<%= dbExists %>";
+  const database = "<%= database %>";
 
-  const credentials = document.createElement("pre")
+  const credentials = document.createElement("pre");
   const renderCredentials = (username, dbPassword) => {
-    if (database === "Postgres") {
-      credentials.innerHTML = `<code>host: ${dbHost}
-username: ${username}
-password: ${dbPassword}
-database: ${username}</code>`
-    } else if (database === "Elasticsearch") {
-      credentials.innerHTML = `<code>host: ${dbHost}
-username: ${username}
-password: ${dbPassword}
-index: ${username}-*</code>`
-    } else {
-      credentials.innerHTML = ""
+    const creds = `host: ${dbHost}\nusername: ${username}\npassword: ${dbPassword}\n`;
+    /**
+     **** EACH TIME A DATABASE IS ADDED, ADD TO THE endingChoice OBJECT ****
+     * This is the only change you need to make if you are altering
+     * this file because another database has been implemented.
+     */
+    const endingChoice = {
+      Postgres: `database: ${username}`,
+      Elasticsearch: `index: ${username}-*`,
+      Arango: `databaseName: ${username}`,
+    };
+    credentials.innerHTML = `<code>${creds}${endingChoice[database]}</code>`;
+    introduction.append(credentials);
+  };
+
+  const content = document.getElementById("content");
+  const renderContent = async (username, dbPassword) => {
+    const r = await fetch(`/lessons/${database}.md`).then((r) => r.text());
+    marked.setOptions({
+      highlight: function (code) {
+        return hljs.highlightAuto(code).value;
+      },
+    });
+    const markedHTML = marked(r);
+    const markedHTMLwithUserData = markedHTML
+      .replace(/@username/gi, username)
+      .replace(/@dbPassword/gi, dbPassword);
+    content.innerHTML = markedHTMLwithUserData;
+  };
+
+  let disabled;
+  const createDb = async () => {
+    if (disabled) return;
+    disabled = true;
+    createDb_button.classList.add("disabled");
+    createDb_button.innerText = "Creating...";
+
+    const res = await fetch(`/api/createDatabase/${database}`, {
+      method: "POST",
+    }).then((r) => r.json());
+    const { error, username, dbPassword, email } = res;
+    if (error) {
+      alert(error.message);
+      disabled = false;
+      createDb_button.classList.remove("disabled");
+      createDb_button.innerText = "Create my database";
+      return;
     }
-    introduction.append(credentials)
-  }
+    alert(
+      email
+        ? "Your database has been successfully created!"
+        : "Your temporary database has been successfully created!\r\nSince credentials are provided only once, please keep the information somewhere safe."
+    );
+    createDb_button.style.opacity = 0;
+    setTimeout(() => {
+      createDb_button.innerText = "Complete!";
+      createDb_button.style.background = "rgb(10, 170, 75)";
+      createDb_button.style.opacity = 1;
+      setTimeout(() => {
+        renderCredentials(username, dbPassword);
+        renderContent(username, dbPassword);
+      }, 200);
+    }, 200);
+  };
 
-  const content = document.getElementById("content")
-  const renderContent = (username, dbPassword) => {
-    fetch(`/lessons/${database}.md`).then(r => r.text()).then((r) => {
-      marked.setOptions({
-        highlight: function (code) {
-          return hljs.highlightAuto(code).value
-        }
-      })
-      const markedHTML = marked(r)
-      const markedHTMLwithUserData = markedHTML.replace(/@username/gi, username).replace(/@dbPassword/gi, dbPassword)
-      content.innerHTML = markedHTMLwithUserData
-    })
-  }
-  
-  let disabled
-  const createDb = () => {
-    if (disabled) return
-    disabled = true
-    createDb_button.classList.add("disabled")
-    createDb_button.innerText = "Creating..."
-    fetch(`/api/createDatabase/${database}`, { method: "POST" }).then(r => r.json()).then((r) => {
-      if (r.error) {
-        alert(r.error.message)
-        disabled = false
-        createDb_button.classList.remove("disabled")
-        createDb_button.innerText = "Create my database"
-      } else {
-        if (r.email) {
-          alert("Your database is successfully created!")
-        } else {
-          alert("Your temporary database is successfully created!\r\nSince credentials are provided only once, please keep the information somewhere safe.")
-        }
-        createDb_button.style.opacity = 0
-        setTimeout(() => {
-          createDb_button.innerText = "Complete!"
-          createDb_button.style.background = "rgb(10, 170, 75)"
-          createDb_button.style.opacity = 1
-          setTimeout(() => {
-            renderCredentials(r.username, r.dbPassword)
-            renderContent(r.username, r.dbPassword)
-          }, 200)
-        }, 200)
-      }
-    })
-  }
+  const createDb_button = document.createElement("button");
+  createDb_button.id = "createDb";
+  createDb_button.innerText = "Create my database";
+  createDb_button.addEventListener("click", createDb);
 
-  const createDb_button = document.createElement("button")
-  createDb_button.id = "createDb"
-  createDb_button.innerText = "Create my database"
-  createDb_button.addEventListener("click", createDb)
-  
-  const introduction = document.getElementById("introduction")
-  if (!username) {
-    introduction.innerHTML = `
-      <p>In this module, you can learn how to use ${database}. Don't have ${database} installed on your local machine yet? Fear not! We can make a ${database} database for you. Simply click on the button below to create your temporary ${database} database. Credentials for your database will appear after it is done being created.</p>
-      <p>Temporary database credentials will expire in 5 days. If you want, you can sign up with us and get a non-expiring Postgres database!</p>
-    `
-    introduction.append(createDb_button)
-    renderContent("username", "dbPassword")
-  } else if (!dbExists) {
-    introduction.innerHTML = `
-      <p>In this module, you can learn how to use ${database}. Don't have ${database} installed on your local machine yet? Fear not! We can make an ${database} database for you. Simply click on the button below to create your ${database} database. Credentials for your database will appear after it is done being created.</p>
-    `
-    introduction.append(createDb_button)
-    renderContent("username", "dbPassword")
-  } else {
-    introduction.innerHTML = `
-<p>In this module, you can learn how to use ${database}. You have already created an ${database} database on our server. Here are the credentials for your database.</p>
-    `
-    renderCredentials(username, dbPassword)
-    renderContent(username, dbPassword)
-  }
-
+  (function setIntroduction() {
+    const vowelsTable = {
+      A: true,
+      E: true,
+      I: true,
+      O: true,
+      U: true,
+    };
+    const introduction = document.getElementById("introduction");
+    const a = `a${vowelsTable[database[0]] ? "n" : ""}`;
+    const messageOpening = `<p>In this module, you can learn how to use ${database}. `;
+    if (!username || !dbExists) {
+      const tense = !username ? "temporary " : "";
+      const messageMiddle = `Don't have ${database} installed on your local machine yet? Fear not! We can make ${a} ${database} database for you. Simply click on the button below to create your ${tense}database. Credentials for your database will appear after it is done being created.</p>`;
+      const messageEnding = !username
+        ? `<p>Temporary database credentials will expire in 5 days. If you want, you can sign up with us and get a non-expiring ${database} database!</p>`
+        : "";
+      introduction.innerHTML = `${messageOpening}${messageMiddle}${messageEnding}`;
+      introduction.append(createDb_button);
+      return renderContent("username", "dbPassword");
+    }
+    introduction.innerHTML = `${messageOpening}You have already created ${a} ${database} database on our server. Here are the credentials for your database.</p>`;
+    renderCredentials(username, dbPassword);
+    renderContent(username, dbPassword);
+  })();
 </script>
-
 <style>
   #createDb {
     display: block;

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -18,9 +18,9 @@
         <h4 class="db-title">MongoDB (coming next sprint!)</h4>
         <p class="db-discription">An open source database management system using a document-oriented database model that supports various forms of data.<p>
 			</blockquote>
-      <blockquote id="neo4j" class="db-card darkenCards umami--click--neo4j-button">
-        <h4 class="db-title">Neo4j (coming next sprint!)</h4>
-        <p class="db-discription">A graph database management system that is the most popular graph database and the 22nd most popular database overall.</p>
+      <blockquote id="arango" class="db-card umami--click--neo4j-button">
+        <h4 class="db-title">Arango (coming next sprint!)</h4>
+        <p class="db-discription">A multi-model database. Whether you want to store data in tables or graphs is up to you!</p>
       </blockquote>
 
     <p style="text-align:center;">Everything we do here is open source. Checkout our github
@@ -72,14 +72,12 @@
         location.href = '/tutorial/Elasticsearch'
       }, 10)
     })
-		/*
-    document.getElementById('mongodb').addEventListener('click', () => {
-      location.href = '/mongodb'
-    })
-    document.getElementById('neo4j').addEventListener('click', () => {
-      location.href = '/neo4j'
+    // document.getElementById('mongodb').addEventListener('click', () => {
+    //   location.href = '/mongodb'
+    // })
+    document.getElementById('arango').addEventListener('click', () => {
+      location.href = '/tutorial/Arango'
 		})
-		*/
   </script>
 
   <script async defer data-website-id="d367293a-0e30-4ae1-bdce-3651e1b64909" src="https://analytics.learndatabases.dev/umami.js"></script>

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -14,14 +14,14 @@
         <h4 class="db-title">Elasticsearch</h4>
         <p class="db-discription">A highly scalable full-text search analytics engine. It allows you to store, search and analyze big volumes of data quickly and in near real time.</p>
       </blockquote>
+      <blockquote id="arango" class="db-card umami--click--arango-button">
+        <h4 class="db-title">Arango</h4>
+        <p class="db-discription">A multi-model database. Whether you want to store data in tables or graphs is up to you!</p>
+      </blockquote>
       <blockquote id="mongodb" class="db-card darkenCards umami--click--mongodb-button">
         <h4 class="db-title">MongoDB (coming next sprint!)</h4>
         <p class="db-discription">An open source database management system using a document-oriented database model that supports various forms of data.<p>
 			</blockquote>
-      <blockquote id="arango" class="db-card umami--click--neo4j-button">
-        <h4 class="db-title">Arango (coming next sprint!)</h4>
-        <p class="db-discription">A multi-model database. Whether you want to store data in tables or graphs is up to you!</p>
-      </blockquote>
 
     <p style="text-align:center;">Everything we do here is open source. Checkout our github
     <a href="https://github.com/garageScript/databases" class="umami--click--github-anchor">Here</a></p>


### PR DESCRIPTION
The websites needs to display a tutorial, as well as all the ability to create a database for Arango. 
This PR **cannot** be merged until we have a production arango database.
This PR will:
* Include a tutorial for Arango
* Update relevant back-end files needed to enable `create my database` button for on the Arango tutorial page
* Update tutorial to display `an` instead of `a` before database names that start with a vowel
<img width="833" alt="Screen Shot 2020-10-07 at 11 44 41 AM" src="https://user-images.githubusercontent.com/45890848/95374016-a9167200-0892-11eb-8c35-4762648f9a85.png">
<img width="823" alt="Screen Shot 2020-10-07 at 11 25 20 AM" src="https://user-images.githubusercontent.com/45890848/95374029-afa4e980-0892-11eb-9e94-0ab95f84dbaf.png">
<img width="846" alt="Screen Shot 2020-10-07 at 11 25 41 AM" src="https://user-images.githubusercontent.com/45890848/95374051-b3d10700-0892-11eb-840f-743f356ea165.png">
<img width="815" alt="Screen Shot 2020-10-07 at 11 25 47 AM" src="https://user-images.githubusercontent.com/45890848/95374058-b6336100-0892-11eb-8c58-3b56a729fa69.png">
