### PR TITLE
closes #241 - init commiit, fix typo

### DIFF
--- a/database/arango/arango.js
+++ b/database/arango/arango.js
@@ -55,7 +55,7 @@ arangoModule.createAccount = async (account) => {
 
   try {
     await db.createDatabase(username, {
-      users: [{ username, password: dbPassword }],
+      users: [{ username, passwd: dbPassword }],
     });
     logger.info(`Successfully created Arango user and database ${username}`);
   } catch (err) {


### PR DESCRIPTION
## The issue
#241 
The arangoJS API was used wrong -- there was a word that was supposed to be spelled `passwd`, but it got spelled as `password` instead.

## This PR will
* Fix the typo error