### PR TITLE
Closes #161 - add Ignite key-value in-memory database

### DIFF
--- a/database/ignite/ignite.js
+++ b/database/ignite/ignite.js
@@ -1,0 +1,76 @@
+const IgniteClient = require("apache-ignite-client");
+const logger = require("./../../lib/log")(__filename);
+const { SqlFieldsQuery } = require("apache-ignite-client/lib/Query");
+const IgniteClientConfiguration = IgniteClient.IgniteClientConfiguration;
+const CacheConfiguration = IgniteClient.CacheConfiguration;
+require("dotenv").config();
+let igniteModule = {};
+let igniteClient;
+igniteModule.startIgnite = async () => {
+  try {
+    igniteClient = new IgniteClient();
+    const configuration = new IgniteClientConfiguration(process.env.IGNITE_HOST)
+      .setUserName(process.env.IGNITE_USER)
+      .setPassword(process.env.IGNITE_PASSWORD);
+    await igniteClient.connect(configuration);
+    logger.info("Connected to Ignite database");
+  } catch (err) {
+    logger.error(err);
+    throw new Error(err);
+  }
+};
+igniteModule.checkAccount = async (username) => {
+  if (!username) return;
+  try {
+    const caches = await igniteClient.cacheNames();
+    return caches.includes(username);
+  } catch (err) {
+    logger.error(`Error checking ignite database for ${username}`);
+    throw new Error(err);
+  }
+};
+igniteModule.closeIgnite = async () => {
+  try {
+    await igniteClient.disconnect();
+    logger.info("Closed connection to Ignite database");
+  } catch (err) {
+    logger.error(`Error closing connection to Ignite database`);
+    throw new Error(err);
+  }
+};
+
+igniteModule.createAccount = async (user) => {
+  const { username, dbPassword } = user;
+  if (!username || !dbPassword) return;
+  try {
+    const cache = await igniteClient.getOrCreateCache(
+      username,
+      new CacheConfiguration().setSqlSchema("PUBLIC")
+    );
+    await cache.query(
+      new SqlFieldsQuery(
+        `CREATE USER "${username}" WITH PASSWORD '${dbPassword}'`
+      )
+    );
+    logger.info(`Successfully created ${username} cache`);
+  } catch (err) {
+    logger.error(`Error creating ignite ${username}`);
+    throw new Error(err);
+  }
+};
+igniteModule.deleteAccount = async (username) => {
+  if (!username) return;
+  try {
+    const cache = await igniteClient.getOrCreateCache(
+      username,
+      new CacheConfiguration().setSqlSchema("PUBLIC")
+    );
+    await cache.query(new SqlFieldsQuery(`DROP USER "${username}"`));
+    await igniteClient.destroyCache(username);
+    logger.info(`Successfully deleted ${username} cache`);
+  } catch (err) {
+    logger.error(`Error deleting ignite ${username}`);
+    throw new Error(err);
+  }
+};
+module.exports = igniteModule;

--- a/database/ignite/ignite.test.js
+++ b/database/ignite/ignite.test.js
@@ -1,0 +1,110 @@
+jest.mock("apache-ignite-client");
+jest.mock("../../lib/log");
+const logGen = require("../../lib/log");
+const logger = {
+  info: jest.fn(),
+  error: jest.fn(),
+};
+logGen.mockReturnValue(logger);
+require("dotenv").config();
+const {
+  startIgnite,
+  createAccount,
+  deleteAccount,
+  checkAccount,
+  closeIgnite,
+} = require("./ignite");
+
+const IgniteClient = require("apache-ignite-client");
+const mockClient = {
+  cacheNames: jest.fn(),
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+  getOrCreateCache: jest.fn().mockReturnThis(),
+  query: jest.fn(),
+  destroyCache: jest.fn(),
+};
+IgniteClient.mockImplementation(() => mockClient);
+const mockConfig = {
+  setUserName: jest.fn().mockReturnThis(),
+  setPassword: jest.fn().mockReturnThis(),
+};
+IgniteClient.IgniteClientConfiguration.mockImplementation(() => mockConfig);
+describe("IgniteDb functions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  const user = { username: "username", dbPassword: "password" };
+  it("should start Ignite client", () => {
+    startIgnite();
+    expect(IgniteClient).toHaveBeenCalledTimes(1);
+    expect(mockClient.connect).toHaveBeenCalledTimes(1);
+    expect(IgniteClient.IgniteClientConfiguration).toHaveBeenCalledTimes(1);
+    expect(mockConfig.setUserName.mock.calls[0][0]).toEqual("ignite");
+    expect(mockConfig.setPassword.mock.calls[0][0]).toEqual("ignite");
+  });
+  it("should throw an error if starting client goes wrong", async () => {
+    try {
+      mockClient.connect.mockReturnValue(Promise.reject());
+      expect(await startIgnite()).rejects.toThrow();
+    } catch (err) {
+      expect(logger.error).toHaveBeenCalledTimes(1);
+    }
+  });
+  it("should close ignite client", () => {
+    closeIgnite();
+    expect(mockClient.disconnect).toHaveBeenCalledTimes(1);
+  });
+  it("should call logger error if closing client goes wrong", async () => {
+    try {
+      mockClient.disconnect.mockReturnValue(Promise.reject());
+      await closeIgnite();
+    } catch (err) {
+      expect(logger.error).toHaveBeenCalledTimes(1);
+    }
+  });
+  it("should check for existsting accounts", async () => {
+    mockClient.cacheNames.mockReturnValue(["testName", "", "username"]);
+    const result = await checkAccount(user.username);
+    expect(mockClient.cacheNames).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(true);
+  });
+  it("should call logger error if checking for account goes wrong", async () => {
+    try {
+      mockClient.cacheNames.mockReturnValue(Promise.reject());
+      await checkAccount(user.username);
+    } catch (err) {
+      expect(logger.error).toHaveBeenCalledTimes(1);
+    }
+  });
+  it("should create new account", async () => {
+    await createAccount(user);
+    expect(mockClient.getOrCreateCache.mock.calls[0][0]).toEqual(user.username);
+  });
+  it("should delete user", async () => {
+    await deleteAccount(user.username);
+    expect(mockClient.getOrCreateCache.mock.calls[0][0]).toEqual(user.username);
+    expect(mockClient.destroyCache.mock.calls[0][0]).toEqual(user.username);
+  });
+  it("should call logger error if creating a user goes wrong", async () => {
+    try {
+      mockClient.getOrCreateCache.mockReturnValue(Promise.reject());
+      expect(await createAccount(user)).rejects.toThrow();
+    } catch (err) {
+      expect(logger.error).toHaveBeenCalledTimes(1);
+    }
+  });
+  it("should return undefined if no arguments were provided", async () => {
+    expect(await createAccount({})).toEqual(undefined);
+    expect(await checkAccount("")).toEqual(undefined);
+    expect(await deleteAccount("")).toEqual(undefined);
+  });
+  it("should calll logger error if deleting user goes wrong", async () => {
+    try {
+      mockClient.getOrCreateCache.mockReturnValue(Promise.reject());
+      await deleteAccount(user.username);
+    } catch (err) {
+      expect(logger.error).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/database/ignite/igniteConfig.xml
+++ b/database/ignite/igniteConfig.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+<bean class="org.apache.ignite.configuration.IgniteConfiguration">
+    <property name="dataStorageConfiguration">
+        <bean class="org.apache.ignite.configuration.DataStorageConfiguration">
+            <property name="defaultDataRegionConfiguration">
+                <bean class="org.apache.ignite.configuration.DataRegionConfiguration">
+                    <property name="maxSize" value="#{200 * 1024 * 1024}"/>
+                    <property name="persistenceEnabled" value="true"/>
+                </bean>
+            </property>
+        </bean>
+    </property>
+
+   <property name="authenticationEnabled" value="true"/>
+
+</bean>
+</beans>

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,7 @@ const db = require("../sequelize/db");
 const pg = require("../database/postgres/pg");
 const arango = require("../database/arango/arango");
 const es = require("../database/elasticsearch/elastic");
+const ignite = require("../database/ignite/ignite");
 const logger = require("./log")(__filename);
 
 const util = {};
@@ -36,6 +37,9 @@ util.cleanAnonymous = async () => {
 
         const arangoDbExists = await arango.checkIfDatabaseExists(username);
         if (arangoDbExists) await arango.deleteAccount(username);
+
+        const igniteDbExists = await ignite.checkAccount(username);
+        if(igniteDbExists) await ignite.deleteAccount(username);
 
         return await user.destroy();
       })

--- a/lib/util.test.js
+++ b/lib/util.test.js
@@ -3,6 +3,7 @@ jest.mock("../sequelize/db");
 jest.mock("../database/postgres/pg");
 jest.mock("../database/arango/arango");
 jest.mock("../database/elasticsearch/elastic");
+jest.mock("../database/ignite/ignite");
 jest.mock("./log");
 
 const sequelize = require("sequelize");
@@ -10,6 +11,7 @@ const db = require("../sequelize/db");
 const pg = require("../database/postgres/pg");
 const es = require("../database/elasticsearch/elastic");
 const arango = require("../database/arango/arango");
+const ignite = require("../database/ignite/ignite");
 
 sequelize.Op = { and: "and", lt: "lt" };
 const Accounts = {
@@ -21,6 +23,7 @@ db.getModels = () => {
 pg.deletePgAccount = jest.fn();
 es.deleteAccount = jest.fn();
 arango.deleteAccount = jest.fn();
+ignite.deleteAccount = jest.fn();
 const logGen = require("./log");
 const logger = {
   info: jest.fn(),
@@ -58,16 +61,19 @@ describe("Testing cleanAnonymous function", () => {
     expect(pg.deletePgAccount).not.toHaveBeenCalled();
     expect(es.deleteAccount).not.toHaveBeenCalled();
     expect(arango.deleteAccount).not.toHaveBeenCalled();
+    expect(ignite.deleteAccount).not.toHaveBeenCalled();
   });
   it("should call database functions if expired accounts are found", async () => {
     Accounts.findAll.mockReturnValue([{ destroy: () => {} }]);
     pg.userHasPgAccount = () => true;
     es.checkAccount = () => true;
     arango.checkIfDatabaseExists = () => true;
+    ignite.checkAccount = ()=>true;
     await util.cleanAnonymous();
     expect(pg.deletePgAccount).toHaveBeenCalled();
     expect(es.deleteAccount).toHaveBeenCalled();
     expect(arango.deleteAccount).toHaveBeenCalled();
+    expect(ignite.deleteAccount).toHaveBeenCalled();
   });
   it("should call logger.error if cleaning fails", async () => {
     Accounts.findAll.mockImplementation(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1590,6 +1590,15 @@
         "picomatch": "^2.0.4"
       }
     },
+    "apache-ignite-client": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/apache-ignite-client/-/apache-ignite-client-1.0.0.tgz",
+      "integrity": "sha512-rWSDd/PArxkmhQr0e0e89RfPt/AU3j1B+g+vVNTE4qKAIi5zssm6CTot7tRLRTcuKGvU+yVxqyzmwtVzwFiklQ==",
+      "requires": {
+        "decimal.js": "^10.2.1",
+        "long": "^4.0.0"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -3073,6 +3082,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "decimal.js": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -5981,6 +5995,11 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "lowercase-keys": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@types/node-fetch": "^2.5.7",
+    "apache-ignite-client": "^1.0.0",
     "arangojs": "^7.0.2",
     "base-x": "^3.0.8",
     "bcrypt": "^5.0.0",

--- a/public/lessons/Ignite.md
+++ b/public/lessons/Ignite.md
@@ -1,0 +1,59 @@
+
+# Intro
+
+In-memory database is a database which relies primarily on memory for data storage. 
+
+Pros:
+* Performance. RAM is way faster than any disks IOs
+
+Cons:
+* Data persistence can be tricky
+
+Some datasets could be stored entirely in memory but most often in-memory databases are used as caches.  
+
+# Apache Ignite
+
+Ignite is an open source distributed in-memory database. It can be used as cache, data grid or key-value store. In our case we will use the latter.
+
+Key-value store is the simplest data model, one unique key which is mapped to some value. With no schema limitations writes are very fast, but since database doesn't know anything about the value you can't use indexes to speed up searches. 
+
+# Client
+
+Ignite provides their own node.js client [apache-ignite-client](https://www.npmjs.com/package/apache-ignite-client). 
+
+To connect to database:
+```
+const IgniteClient = require("apache-ignite-client");
+const IgniteClientConfiguration = IgniteClient.IgniteClientConfiguration;
+
+const igniteClientConfiguration = new IgniteClientConfiguration("host")
+  .setUserName("username")
+  .setPassword("password");
+const connect = async () => {
+  const igniteClient = new IgniteClient();
+  await igniteClient.connect(igniteClientConfiguration);
+};
+connect();
+```
+
+To add values into cache you need to connect to cache, specify data type and its key:
+
+```
+const ObjectType = IgniteClient.ObjectType;
+const basicOperations = async () => {
+  const igniteClient = new IgniteClient();
+  await igniteClient.connect(igniteClientConfiguration);
+  console.log("successfully connected");
+  const cache = (await igniteClient.getOrCreateCache("username")).setKeyType(
+    ObjectType.PRIMITIVE_TYPE.INTEGER
+  );
+  await cache.put(1, "hello world");
+  console.log(await cache.get(1));
+  igniteClient.disconnect();
+};
+basicOperations();
+```
+
+You can find more examples [here](https://github.com/apache/ignite/tree/master/modules/platforms/nodejs/examples).
+
+*Under construction* 

--- a/src/routes/renderRoutes.js
+++ b/src/routes/renderRoutes.js
@@ -2,6 +2,7 @@ const db = require("../../sequelize/db");
 const es = require("../../database/elasticsearch/elastic");
 const pg = require("../../database/postgres/pg");
 const arangoModule = require("../../database/arango/arango");
+const igniteModule = require("../../database/ignite/ignite");
 require("dotenv").config();
 const routes = {};
 
@@ -10,6 +11,7 @@ const dev_dbHost = {
   Postgres: process.env.HOST,
   Elasticsearch: process.env.ES_HOST,
   Arango: process.env.ARANGO_URL,
+  Ignite:process.env.IGNITE_HOST
 };
 
 // This is the 'host' url for a person's database credentials in prod.
@@ -17,12 +19,14 @@ const dbHost = {
   Postgres: "learndatabases.dev",
   Elasticsearch: "elastic.learndatabases.dev",
   Arango: "arangodb.learndatabases.dev",
+  Ignite:"ADD_IGNITE_HOST"
 };
 
 const checkAccount = {
   Postgres: pg.userHasPgAccount,
   Elasticsearch: es.checkAccount,
   Arango: arangoModule.checkIfDatabaseExists,
+  Ignite: igniteModule.checkAccount
 };
 
 const prod = () => {

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -10,6 +10,7 @@ const db = require("../../sequelize/db");
 const pgModule = require("../../database/postgres/pg");
 const es = require("../../database/elasticsearch/elastic");
 const arangoModule = require("../../database/arango/arango");
+const igniteModule = require("../../database/ignite/ignite");
 const routes = {};
 
 routes.resetPasswordEmail = async (req, res) => {
@@ -143,6 +144,7 @@ const createDatabaseAccount = {
   Postgres: pgModule.userHasPgAccount,
   Elasticsearch: es.createAccount,
   Arango: arangoModule.createAccount,
+  Ignite:igniteModule.createAccount
 };
 
 routes.createDatabase = async (req, res) => {

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ const util = require("../lib/util");
 const dbModule = require("../sequelize/db");
 const session = require("express-session");
 const pgModule = require("../database/postgres/pg");
+const igniteModule = require("../database/ignite/ignite");
 const {
   resetPasswordEmail,
   createUser,
@@ -30,6 +31,7 @@ const startServer = async (portNumber) => {
   await dbModule.start();
   await pgModule.startPGDB();
   await arangoModule.startArangoDB();
+  await igniteModule.startIgnite();
 
   cleaner = await util.cleanAnonymous();
 
@@ -89,6 +91,7 @@ const stopServer = () => {
     dbModule.close();
     pgModule.closePGDB();
     arangoModule.closeArangoDB();
+    igniteModule.closeIgnite();
     logger.info("DB has been closed");
     server.close(() => {
       logger.info("The server has been closed");

--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -91,6 +91,7 @@ exports[`test welcome page should render arango page correctly 1`] = `
       Postgres: \`database: \${username}\`,
       Elasticsearch: \`index: \${username}-*\`,
       Arango: \`databaseName: \${username}\`,
+      Ignite: \`cache: \${username}\`
     };
     credentials.innerHTML = \`<code>\${creds}\${endingChoice[database]}</code>\`;
     introduction.append(credentials);
@@ -281,6 +282,198 @@ exports[`test welcome page should render elasticsearch page correctly 1`] = `
       Postgres: \`database: \${username}\`,
       Elasticsearch: \`index: \${username}-*\`,
       Arango: \`databaseName: \${username}\`,
+      Ignite: \`cache: \${username}\`
+    };
+    credentials.innerHTML = \`<code>\${creds}\${endingChoice[database]}</code>\`;
+    introduction.append(credentials);
+  };
+
+  const content = document.getElementById(\\"content\\");
+  const renderContent = async (username, dbPassword) => {
+    const r = await fetch(\`/lessons/\${database}.md\`).then((r) => r.text());
+    marked.setOptions({
+      highlight: function (code) {
+        return hljs.highlightAuto(code).value;
+      },
+    });
+    const markedHTML = marked(r);
+    const markedHTMLwithUserData = markedHTML
+      .replace(/@username/gi, username)
+      .replace(/@dbPassword/gi, dbPassword);
+    content.innerHTML = markedHTMLwithUserData;
+  };
+
+  let disabled;
+  const createDb = async () => {
+    if (disabled) return;
+    disabled = true;
+    createDb_button.classList.add(\\"disabled\\");
+    createDb_button.innerText = \\"Creating...\\";
+
+    const res = await fetch(\`/api/createDatabase/\${database}\`, {
+      method: \\"POST\\",
+    }).then((r) => r.json());
+    const { error, username, dbPassword, email } = res;
+    if (error) {
+      alert(error.message);
+      disabled = false;
+      createDb_button.classList.remove(\\"disabled\\");
+      createDb_button.innerText = \\"Create my database\\";
+      return;
+    }
+    alert(
+      email
+        ? \\"Your database has been successfully created!\\"
+        : \\"Your temporary database has been successfully created!\\\\r\\\\nSince credentials are provided only once, please keep the information somewhere safe.\\"
+    );
+    createDb_button.style.opacity = 0;
+    setTimeout(() => {
+      createDb_button.innerText = \\"Complete!\\";
+      createDb_button.style.background = \\"rgb(10, 170, 75)\\";
+      createDb_button.style.opacity = 1;
+      setTimeout(() => {
+        renderCredentials(username, dbPassword);
+        renderContent(username, dbPassword);
+      }, 200);
+    }, 200);
+  };
+
+  const createDb_button = document.createElement(\\"button\\");
+  createDb_button.id = \\"createDb\\";
+  createDb_button.innerText = \\"Create my database\\";
+  createDb_button.addEventListener(\\"click\\", createDb);
+
+  (function setIntroduction() {
+    const vowelsTable = [\\"A\\", \\"E\\", \\"I\\", \\"O\\", \\"U\\"].reduce((acc, vowel) => {
+      acc[vowel] = true;
+      return acc;
+    }, {});
+    const a = \`a\${vowelsTable[database[0]] ? \\"n\\" : \\"\\"}\`;
+    const introduction = document.getElementById(\\"introduction\\");
+    const messageOpening = \`<p>In this module, you can learn how to use \${database}. \`;
+    if (!username || !dbExists) {
+      const tense = !username ? \\"temporary \\" : \\"\\";
+      const messageMiddle = \`Don't have \${database} installed on your local machine yet? Fear not! We can make \${a} \${database} database for you. Simply click on the button below to create your \${tense}database. Credentials for your database will appear after it is done being created.</p>\`;
+      const messageEnding = !username
+        ? \`<p>Temporary database credentials will expire in 5 days. If you want, you can sign up with us and get a non-expiring \${database} database!</p>\`
+        : \\"\\";
+      introduction.innerHTML = \`\${messageOpening}\${messageMiddle}\${messageEnding}\`;
+      introduction.append(createDb_button);
+      return renderContent(\\"username\\", \\"dbPassword\\");
+    }
+    introduction.innerHTML = \`\${messageOpening}You have already created \${a} \${database} database on our server. Here are the credentials for your database.</p>\`;
+    renderCredentials(username, dbPassword);
+    renderContent(username, dbPassword);
+  })();
+</script>
+<style>
+  #createDb {
+    display: block;
+    margin: auto;
+    margin-top: 26px;
+    margin-bottom: 26px;
+    transition: 0.2s;
+  }
+
+  #createDb.disabled {
+    cursor: default;
+  }
+</style>
+"
+`;
+
+exports[`test welcome page should render ignite page correctly 1`] = `
+"<!--views/partials/head.ejs-->
+<meta charset='UTF-8'>
+<!--CSS (load bootstrap from a CDN)-->
+<link rel=\\"stylesheet\\" href=\\"https://cdn.jsdelivr.net/npm/open-fonts@1.1.1/fonts/inter.min.css\\">
+<link rel=\\"stylesheet\\" href=\\"https://cdn.jsdelivr.net/npm/@exampledev/new.css@1.1.2/new.min.css\\">
+<link rel=\\"icon\\" type=\\"image/gif\\" href=\\"/database.gif\\">
+<style>
+    input {
+        text-align: center;
+        width: 400px;
+        height: 40px;
+        margin: 5px;
+    }
+    button {
+        width: 400px;
+        height: 40px;
+        margin: 10px;
+    }
+    .home {
+        cursor: pointer;
+    }
+    .card {
+        width: 450px;
+        margin: auto;
+    }
+    .card > * {
+        text-align: center;
+    }
+    .subtitle {
+        margin: 10px;
+    }
+    .body {
+        margin: 10px;
+    }
+</style>
+<html lang=\\"en\\">
+  <head>
+    <title>learndatabases.dev</title>
+  </head>
+  <header>
+    <h1 class=\\"home umami--click--home-button\\">Learn Databases</h1>
+    
+    
+      <p><a href=\\"/signin\\" class=\\"umami--click--login-button\\">Login</a> / <a href=\\"/signup\\" class=\\"umami--click--signup-button\\">Signup</a></p>
+    
+  </header>
+</html>
+<script>
+  const home = document.querySelector('.home')
+  home.addEventListener('click', () => {
+    return location.href = '/'
+  })
+
+  
+</script>
+
+<h3>Learn Ignite</h3>
+<div id=\\"introduction\\"></div>
+<div id=\\"content\\"></div>
+<script src=\\"https://cdn.jsdelivr.net/npm/marked/marked.min.js\\"></script>
+<script
+  src=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/highlight.min.js\\"
+  integrity=\\"sha512-TDKKr+IvoqZnPzc3l35hdjpHD0m+b2EC2SrLEgKDRWpxf2rFCxemkgvJ5kfU48ip+Y+m2XVKyOCD85ybtlZDmw==\\"
+  crossorigin=\\"anonymous\\"
+></script>
+<link
+  rel=\\"stylesheet\\"
+  href=\\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.2.0/styles/tomorrow.min.css\\"
+  integrity=\\"sha512-r3qr7vMdHYmWUzqC7l4H/W03ikAyiFIQld+B71yAmHhu7wcsnvm/adhikM+FzDxxK9ewznhCVnAm+yYZpPBnSg==\\"
+  crossorigin=\\"anonymous\\"
+/>
+<script>
+  const dbHost = \\"ADD_IGNITE_HOST\\";
+  const username = \\"\\";
+  const dbPassword = \\"\\";
+  const dbExists = \\"\\";
+  const database = \\"Ignite\\";
+
+  const credentials = document.createElement(\\"pre\\");
+  const renderCredentials = (username, dbPassword) => {
+    const creds = \`host: \${dbHost}\\\\nusername: \${username}\\\\npassword: \${dbPassword}\\\\n\`;
+    /**
+     **** EACH TIME A DATABASE IS ADDED, ADD TO THE endingChoice OBJECT ****
+     * This is the only change you need to make if you are altering
+     * this file because another database has been implemented.
+     */
+    const endingChoice = {
+      Postgres: \`database: \${username}\`,
+      Elasticsearch: \`index: \${username}-*\`,
+      Arango: \`databaseName: \${username}\`,
+      Ignite: \`cache: \${username}\`
     };
     credentials.innerHTML = \`<code>\${creds}\${endingChoice[database]}</code>\`;
     introduction.append(credentials);
@@ -471,6 +664,7 @@ exports[`test welcome page should render postgres page correctly 1`] = `
       Postgres: \`database: \${username}\`,
       Elasticsearch: \`index: \${username}-*\`,
       Arango: \`databaseName: \${username}\`,
+      Ignite: \`cache: \${username}\`
     };
     credentials.innerHTML = \`<code>\${creds}\${endingChoice[database]}</code>\`;
     introduction.append(credentials);
@@ -1056,6 +1250,10 @@ exports[`test welcome page should render welcome page correctly 1`] = `
         <h4 class=\\"db-title\\">Arango</h4>
         <p class=\\"db-discription\\">A multi-model database. Whether you want to store data in tables or graphs is up to you!</p>
       </blockquote>
+      <blockquote id=\\"ignite\\" class=\\"db-card umami--click--ignite-button\\">
+        <h4 class=\\"db-title\\">Apache Ignite</h4>
+        <p class=\\"db-discription\\">In-memory database</p>
+      </blockquote
       <blockquote id=\\"mongodb\\" class=\\"db-card darkenCards umami--click--mongodb-button\\">
         <h4 class=\\"db-title\\">MongoDB (coming next sprint!)</h4>
         <p class=\\"db-discription\\">An open source database management system using a document-oriented database model that supports various forms of data.<p>
@@ -1115,6 +1313,9 @@ exports[`test welcome page should render welcome page correctly 1`] = `
     // })
     document.getElementById('arango').addEventListener('click', () => {
       location.href = '/tutorial/Arango'
+    })
+    document.getElementById('ignite').addEventListener('click', () => {
+      location.href = '/tutorial/Ignite'
 		})
   </script>
 

--- a/tests/integration/welcome.test.js
+++ b/tests/integration/welcome.test.js
@@ -78,4 +78,11 @@ describe("test welcome page", () => {
     );
     expect(result).toMatchSnapshot();
   });
+  test("should render ignite page correctly", async () => {
+    process.env = { ...process.env, NODE_ENV: "CI" };
+    const result = await fetch(baseUrl + "tutorial/Ignite").then((r) =>
+      r.text()
+    );
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/views/tutorial.ejs
+++ b/views/tutorial.ejs
@@ -33,6 +33,7 @@
       Postgres: `database: ${username}`,
       Elasticsearch: `index: ${username}-*`,
       Arango: `databaseName: ${username}`,
+      Ignite: `cache: ${username}`
     };
     credentials.innerHTML = `<code>${creds}${endingChoice[database]}</code>`;
     introduction.append(credentials);

--- a/views/welcome.ejs
+++ b/views/welcome.ejs
@@ -18,6 +18,10 @@
         <h4 class="db-title">Arango</h4>
         <p class="db-discription">A multi-model database. Whether you want to store data in tables or graphs is up to you!</p>
       </blockquote>
+      <blockquote id="ignite" class="db-card umami--click--ignite-button">
+        <h4 class="db-title">Apache Ignite</h4>
+        <p class="db-discription">In-memory database</p>
+      </blockquote
       <blockquote id="mongodb" class="db-card darkenCards umami--click--mongodb-button">
         <h4 class="db-title">MongoDB (coming next sprint!)</h4>
         <p class="db-discription">An open source database management system using a document-oriented database model that supports various forms of data.<p>
@@ -77,6 +81,9 @@
     // })
     document.getElementById('arango').addEventListener('click', () => {
       location.href = '/tutorial/Arango'
+    })
+    document.getElementById('ignite').addEventListener('click', () => {
+      location.href = '/tutorial/Ignite'
 		})
   </script>
 


### PR DESCRIPTION
While Redis supports creating username-password pairs with Access Control List most node.js clients still don't have this feature. Some clients allow you to authorize from node, but creating and deleting users still needs to be done via redis-cli. So Redis is not an option. The same applies to Memcached and probably most other in-memory databases. Since these databases were designed as caches their security is either non-existent or they support only one global password. 

To safely merge:
* Apache Ignite needs to be [installed](https://ignite.apache.org/docs/latest/quick-start/nodejs) (requires JDK)
* `IGNITE_HOST`, `IGNITE_USER` and `IGNITE_PASSWORD` should be added to .env file. Default user-password is `ignite`, host is `127.0.0.1:10800`

Start the server with provided configuration `bash ignite.sh path-to-igniteConfig.xml`. It's configured to have persistence (if server runs out of memory heap file on disk will be used, it's also a requirement for authentication for some reason) and to limit in-memory region to 200mb. 

Tutorial is pretty barebones so far, additions are welcome. 