### PR TITLE
Fix dbExists variable

### DIFF
--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -76,7 +76,7 @@ exports[`test welcome page should render arango page correctly 1`] = `
   const dbHost = \\"arangodb.learndatabases.dev\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
-  const dbExists = \\"\\";
+  const dbExists = ;
   const database = \\"Arango\\";
 
   const credentials = document.createElement(\\"pre\\");
@@ -266,7 +266,7 @@ exports[`test welcome page should render elasticsearch page correctly 1`] = `
   const dbHost = \\"elastic.learndatabases.dev\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
-  const dbExists = \\"\\";
+  const dbExists = ;
   const database = \\"Elasticsearch\\";
 
   const credentials = document.createElement(\\"pre\\");
@@ -456,7 +456,7 @@ exports[`test welcome page should render postgres page correctly 1`] = `
   const dbHost = \\"learndatabases.dev\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
-  const dbExists = \\"\\";
+  const dbExists = ;
   const database = \\"Postgres\\";
 
   const credentials = document.createElement(\\"pre\\");

--- a/views/tutorial.ejs
+++ b/views/tutorial.ejs
@@ -18,7 +18,7 @@
   const dbHost = "<%= dbHost %>";
   const username = "<%= username %>";
   const dbPassword = "<%= dbPassword %>";
-  const dbExists = "<%= dbExists %>";
+  const dbExists = <%= dbExists %>;
   const database = "<%= database %>";
 
   const credentials = document.createElement("pre");


### PR DESCRIPTION
Front takes `dbExists` variable as string (e.g. `"false"`)
So front page always thinks users already created db.
This PR fixes this problem.