### PR TITLE
Pass false to dbExists when db does not exists

### DIFF
--- a/src/routes/renderRoutes.js
+++ b/src/routes/renderRoutes.js
@@ -39,7 +39,7 @@ routes.database = async (req, res) => {
   const { username, dbPassword } = user || {};
   const renderData = { email, username, dbPassword, database };
   renderData.dbHost = prod() ? dbHost[database] : dev_dbHost[database];
-  renderData.dbExists = username && (await checkAccount[database](username));
+  renderData.dbExists = username && (await checkAccount[database](username)) || false;
   res.render("tutorial", renderData);
 };
 

--- a/src/routes/renderRoutes.test.js
+++ b/src/routes/renderRoutes.test.js
@@ -65,6 +65,7 @@ describe("Testing database router", () => {
     expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
       process.env.ARANGO_URL
     );
+    expect(mockResponse.render.mock.calls[0][1].dbExists).toEqual(false);
   });
   test("when database function is called with non-logged in user and Postgres parameter", async () => {
     process.env = { ...process.env, NODE_ENV: "dev" };
@@ -74,6 +75,7 @@ describe("Testing database router", () => {
     expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
       process.env.HOST
     );
+    expect(mockResponse.render.mock.calls[0][1].dbExists).toEqual(false);
   });
   test("when database function is called with non-logged in user and Elasticsearch parameter", async () => {
     process.env = { ...process.env, NODE_ENV: "dev" };
@@ -83,6 +85,7 @@ describe("Testing database router", () => {
     expect(mockResponse.render.mock.calls[0][1].dbHost).toEqual(
       process.env.ES_HOST
     );
+    expect(mockResponse.render.mock.calls[0][1].dbExists).toEqual(false);
   });
   test("when database function is called with logged in user and Arango parameter", async () => {
     process.env = { ...process.env, NODE_ENV: "dev" };

--- a/tests/integration/__snapshots__/welcome.test.js.snap
+++ b/tests/integration/__snapshots__/welcome.test.js.snap
@@ -76,7 +76,7 @@ exports[`test welcome page should render arango page correctly 1`] = `
   const dbHost = \\"arangodb.learndatabases.dev\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
-  const dbExists = ;
+  const dbExists = false;
   const database = \\"Arango\\";
 
   const credentials = document.createElement(\\"pre\\");
@@ -266,7 +266,7 @@ exports[`test welcome page should render elasticsearch page correctly 1`] = `
   const dbHost = \\"elastic.learndatabases.dev\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
-  const dbExists = ;
+  const dbExists = false;
   const database = \\"Elasticsearch\\";
 
   const credentials = document.createElement(\\"pre\\");
@@ -456,7 +456,7 @@ exports[`test welcome page should render postgres page correctly 1`] = `
   const dbHost = \\"learndatabases.dev\\";
   const username = \\"\\";
   const dbPassword = \\"\\";
-  const dbExists = ;
+  const dbExists = false;
   const database = \\"Postgres\\";
 
   const credentials = document.createElement(\\"pre\\");


### PR DESCRIPTION
Currently `dbExists` variable is empty for non-logged in user so front page can't render properly.
This PR fixes this bug.